### PR TITLE
Define the warning filter in pyutils and call it at the very beginning

### DIFF
--- a/neurodamus/__init__.py
+++ b/neurodamus/__init__.py
@@ -18,14 +18,14 @@ except Exception:
 __author__ = "Fernando Pereira <fernando.pereira@epfl.ch>"
 __copyright__ = "2018 Blue Brain Project, EPFL"
 
-# Control matched warning to display once in rank 0.
+# Ignore matched warning in all ranks.
 # "special" binaries built with %intel build_type=Release,RelWithDebInfo flushes
 # denormal results to zero, which triggers the numpy warning for subnormal in every rank
-# after "import h5py". Reduce this type of warning displayed once in rank0.
+# after "import h5py".
 # Note: "special" with build_type = FastDebug/Debug or calling the simulation process
 #     in python (built with gcc) does not have such flush-to-zero warning.
-from .utils import warnings_once
-warnings_once(message="The value of the smallest subnormal for .* type is zero.",
+from .utils import warnings_ignore
+warnings_ignore(message="The value of the smallest subnormal for .* type is zero.",
               category=UserWarning, module="numpy")
 
 # Neurodamus node for setting up a neurodamus execution

--- a/neurodamus/__init__.py
+++ b/neurodamus/__init__.py
@@ -18,6 +18,16 @@ except Exception:
 __author__ = "Fernando Pereira <fernando.pereira@epfl.ch>"
 __copyright__ = "2018 Blue Brain Project, EPFL"
 
+# Control matched warning to display once in rank 0.
+# "special" binaries built with %intel build_type=Release,RelWithDebInfo flushes
+# denormal results to zero, which triggers the numpy warning for subnormal in every rank
+# after "import h5py". Reduce this type of warning displayed once in rank0.
+# Note: "special" with build_type = FastDebug/Debug or calling the simulation process
+#     in python (built with gcc) does not have such flush-to-zero warning.
+from .utils import warnings_once
+warnings_once(message="The value of the smallest subnormal for .* type is zero.",
+              category=UserWarning, module="numpy")
+
 # Neurodamus node for setting up a neurodamus execution
 from .node import Node, Neurodamus
 

--- a/neurodamus/utils/pyutils.py
+++ b/neurodamus/utils/pyutils.py
@@ -197,13 +197,8 @@ def append_recarray(target_array, record):
     return target_array
 
 
-def warnings_once(message="", category=Warning, module=""):
-    """ Control matched warning to display once in rank 0.
+def warnings_ignore(message="", category=Warning, module=""):
+    """ Ignore matched warning in all ranks.
     """
     import warnings
-    from ..core import MPI
-    if MPI.rank == 0:
-        action = "once"
-    else:
-        action = "ignore"
-    warnings.filterwarnings(action, message, category, module)
+    warnings.filterwarnings("ignore", message, category, module)

--- a/neurodamus/utils/pyutils.py
+++ b/neurodamus/utils/pyutils.py
@@ -195,3 +195,15 @@ def append_recarray(target_array, record):
         target_array.resize(nrows+1, refcheck=False)
         target_array[nrows] = record
     return target_array
+
+
+def warnings_once(message="", category=Warning, module=""):
+    """ Control matched warning to display once in rank 0.
+    """
+    import warnings
+    from ..core import MPI
+    if MPI.rank == 0:
+        action = "once"
+    else:
+        action = "ignore"
+    warnings.filterwarnings(action, message, category, module)


### PR DESCRIPTION
## Context
"special" binaries which flushes denormal results to zero triggers the numpy warning for subnormal in every rank
after "import h5py". Neurodamus had a function to ignore this type of warning, but it is insufficient after the recent change of adding "import h5py" at the beginning of `replay.py` instead of in the function call. We are not seeing flooding warnings at the beginning of the simulation before instantiating neuron.

## Scope
Move the warning filter function in `pyutils.py` and call it in `__init__.py` before the first `import node` which calls `import h5py` from replay.py. In this way, we have to ignore the warnings in all ranks.

## Testing
No new test

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
