### PR TITLE
Use 0-based gid for reading GlioVascular sonata edges file

### DIFF
--- a/neurodamus/ngv.py
+++ b/neurodamus/ngv.py
@@ -487,7 +487,7 @@ class GlioVascularManager(ConnectionManagerBase):
 
     def _connect_endfeet(self, astro_id):
 
-        endfeet = self._gliovascular.afferent_edges(astro_id)
+        endfeet = self._gliovascular.afferent_edges(astro_id-1)  # 0-based for libsonata API
         if endfeet.flat_size > 0:
             # Get endfeet input
             parent_section_ids = self._gliovascular.get_attribute('astrocyte_section_id', endfeet)

--- a/tests/test_ngv.py
+++ b/tests/test_ngv.py
@@ -98,8 +98,6 @@ def get_R0pas_ref(astro_id, manager):
     ]
 
 
-@pytest.mark.skip(
-    reason="Seg fault with neurodamus-neocortex-1.12-2.15.0, see BBPBGLIB-1039")
 def test_vasccouplingB_radii():
     load_neurodamus_neocortex_multiscale()
     ndamus = Neurodamus(
@@ -113,7 +111,7 @@ def test_vasccouplingB_radii():
     astro_ids = manager._astro_ids
 
     R0pas = [r for astro_id in astro_ids for r in get_R0pas(astro_id, manager)]
-    R0pas_ref = [r for astro_id in astro_ids for r in get_R0pas_ref(astro_id, manager)]
+    R0pas_ref = [r for astro_id in astro_ids for r in get_R0pas_ref(astro_id-1, manager)]
 
     assert np.allclose(R0pas, R0pas_ref)
 


### PR DESCRIPTION
## Context
Gids are 0-based in sonata circuits and neurodamus converts them to 1-based internally and passes to NEURON. When using libsonata API to read sonata circuits, the input gids should be 0-based. This PR fixes GlioVascularManager in ngv that will use 0-based gids to read the gliovascular edge files.

## Scope
In ngv.py: Convert to 0-based when calling libsonata API, i.e. self._gliovascular.afferent_edges(astro_id-1)

## Testing
Enable and correct test_ngv.py. It was skipped because of BBPBGLIB-1039.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
