### PR TITLE
use libsonata API to read the keys

### DIFF
--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -321,7 +321,7 @@ class SonataConfig:
         }
 
         stimuli = {}
-        for name in self._sections["inputs"].keys():
+        for name in self._sim_conf.list_input_names:
             stimulus = self._translate_dict("inputs", self._sim_conf.input(name))
             self._adapt_libsonata_fields(stimulus)
             stimulus["Pattern"] = "SEClamp" if stimulus["Pattern"] == "seclamp" \
@@ -333,7 +333,7 @@ class SonataConfig:
     @property
     def parsedInjects(self):
         injects = {}
-        for name in self._sections["inputs"].keys():
+        for name in self._sim_conf.list_input_names:
             inj = self._translate_dict("inputs", self._sim_conf.input(name))
             inj.setdefault("Stimulus", name)
             injects["inject"+name] = inj
@@ -346,7 +346,7 @@ class SonataConfig:
             "synapse": "Synapse"
         }
         reports = {}
-        for name in self._sections["reports"].keys():
+        for name in self._sim_conf.list_report_names:
             rep = self._translate_dict("reports", self._sim_conf.report(name))
             # Adapt enums and variable names read from libsonata
             self._adapt_libsonata_fields(rep)


### PR DESCRIPTION
## Context
This PR improves the parsing of sonata config file and align with the parser in libsonata. It reads the key names in the "inputs" and "reports" sections using libsonata API functions.

## Scope
In `sonata_config.py`, call `libsonata.list_input_names` and `libsonata.list_report_names`. 

## Testing
Existing tests 

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
