### PR TITLE
Propagate the log level correctly from the CLI option to Neurodamus class

### DIFF
--- a/neurodamus/commands.py
+++ b/neurodamus/commands.py
@@ -72,7 +72,7 @@ def neurodamus(args=None):
     _filter_warnings()
 
     try:
-        Neurodamus(config_file, True, log_level, **options).run()
+        Neurodamus(config_file, True, logging_level=log_level, **options).run()
     except ConfigurationError as e:  # Common, only show error in Rank 0
         if MPI._rank == 0:           # Use _rank so that we avoid init
             logging.error(str(e))


### PR DESCRIPTION
## Context
After a recent change, the logging level CLI option `--verbose` and `--debug` don't work any more. This PR fixes the logging level of the simulation. 

## Scope
In `Neurodamus::__init__`, the `logging_level` is now the 4th argument.  In `command.py`, when instantiating the `Neurodamus` class, use the keyword argument to set the logging level correctly.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
