### PR TITLE
Preserve the order of stimulus injection & CI fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ set_alt_branches:
 blueconfig_tests:
   variables:
     bb5_build_dir: pipeline
-    PY_NEURODAMUS_BRANCH: $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME
+    PY_NEURODAMUS_BRANCH: $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME
     PARENT_COMMIT_MESSAGE: $CI_COMMIT_MESSAGE
   trigger:
     project: hpc/sim/blueconfigs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ set_alt_branches:
 blueconfig_tests:
   variables:
     bb5_build_dir: pipeline
-    PY_NEURODAMUS_BRANCH: $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME
+    PY_NEURODAMUS_BRANCH: $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
     PARENT_COMMIT_MESSAGE: $CI_COMMIT_MESSAGE
   trigger:
     project: hpc/sim/blueconfigs

--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -333,7 +333,9 @@ class SonataConfig:
     @property
     def parsedInjects(self):
         injects = {}
-        for name in self._sim_conf.list_input_names:
+        # the order of stimulus injection could lead to minor difference on the results
+        # so better to preserve it as in the config file
+        for name in self._sections["inputs"].keys():
             inj = self._translate_dict("inputs", self._sim_conf.input(name))
             inj.setdefault("Stimulus", name)
             injects["inject"+name] = inj


### PR DESCRIPTION
## Context
This PR solves 2 issues:

1. It reverts https://github.com/BlueBrain/neurodamus/commit/0cc296110416d3d4095dbb98590857b7f0877cd9 to preserve the order of stimulus injection
2. Sets the proper branch name of neurodamus to blueconfigs

It seems that in the PR https://github.com/BlueBrain/neurodamus/pull/30 the `blueconfigs` CI didn't get launched with the proper `neurodamus` branch as can be seen from https://bbpgitlab.epfl.ch/hpc/sim/blueconfigs/-/jobs/850462 where the `py-neurodamus` branch is not set by `spack`.
And the PR also reverts the previous commit to preserve the order of stimulus injections read from the sonata config file.

## Scope
Pass to `blueconfigs` trigger the proper env variable to fix `2.`

## Testing
Should be tested by the CI of this PR in the `setup_spack` stage

## Review
* [x] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
