### PR TITLE
From Sonata 0-based spikes to 1-based

### DIFF
--- a/neurodamus/replay.py
+++ b/neurodamus/replay.py
@@ -66,7 +66,7 @@ class SpikeManager:
         spikes = spikes_file.get("spikes/" + population)
         if spikes is None:
             raise MissingSpikesPopulationError("Spikes population not found: " + population)
-        return spikes["timestamps"][...], spikes["node_ids"][...]
+        return spikes["timestamps"][...], spikes["node_ids"][...] + 1
 
     @classmethod
     def _read_spikes_ascii(cls, filename):

--- a/tests/scientific/test_replay.py
+++ b/tests/scientific/test_replay.py
@@ -99,18 +99,18 @@ def test_replay_sonata_spikes(sonata_config):
     conn_2_1 = next(edges_a.get_connections(1, 2))
     time_vec = conn_2_1._replay.time_vec.as_numpy()
     assert len(time_vec) == 11
-    npt.assert_allclose(time_vec[:8], [0.15, 3.45, 6.975, 11.05, 15.5, 20.225, 25.175, 30.3])
+    npt.assert_allclose(time_vec[:8], [0.175, 3.025, 5.7, 8.975, 13.95, 20.15, 26.125, 31.725])
 
     conn_1_2 = next(edges_a.get_connections(2, 1))
     time_vec = conn_1_2._replay.time_vec.as_numpy()
-    assert len(time_vec) == 11
-    npt.assert_allclose(time_vec[:8], [0.175, 3.025, 5.7, 8.975, 13.95, 20.15, 26.125, 31.725])
+    assert len(time_vec) == 13
+    npt.assert_allclose(time_vec[:8], [0.1, 2.275, 4.35, 7.725, 12.525, 16.825, 21.4, 26.05])
 
     # projections get replay too
     edges_a = nd.circuits.get_edge_manager("NodeA", "NodeB")
-    conn_1_1001 = next(edges_a.get_connections(1001, 2))
-    time_vec = conn_1_1001._replay.time_vec.as_numpy()
+    conn_2_1001 = next(edges_a.get_connections(1001, 2))
+    time_vec = conn_2_1001._replay.time_vec.as_numpy()
     assert len(time_vec) == 11
-    npt.assert_allclose(time_vec[:8], [0.15, 3.45, 6.975, 11.05, 15.5, 20.225, 25.175, 30.3])
+    npt.assert_allclose(time_vec[:8], [0.175, 3.025, 5.7, 8.975, 13.95, 20.15, 26.125, 31.725])
 
     os.unlink(config_file.name)

--- a/tests/test_replay_manager.py
+++ b/tests/test_replay_manager.py
@@ -12,7 +12,7 @@ def test_replay_manager_sonata():
 
     timestamps, spike_gids = SpikeManager._read_spikes_sonata(spikes_sonata, "NodeA")
     npt.assert_allclose(timestamps[:8], [0.1, 0.15, 0.175, 2.275, 3.025, 3.45, 4.35, 5.7])
-    npt.assert_equal(spike_gids[:8], [0, 2, 1, 0, 1, 2, 0, 1])
+    npt.assert_equal(spike_gids[:8], [1, 3, 2, 1, 2, 3, 1, 2])
 
     # We do an internal assertion when the population doesnt exist. Verify it works as expected
     with pytest.raises(MissingSpikesPopulationError, match="Spikes population not found"):


### PR DESCRIPTION
## Context
Replay from Sonata spikes suffers from the 0/1-based gids mismatch. We Fix that

## Testing
Changed the tests accordingly

## Review
* [x] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test ~~added~~ fixed
* [ ] Updated Readme, in-code, developer documentation
