### PR TITLE
import h5py in the function call to filter numpy warnings

### DIFF
--- a/neurodamus/replay.py
+++ b/neurodamus/replay.py
@@ -3,7 +3,6 @@ Stimulus implementation where incoming synaptic events are replayed for a single
 """
 from __future__ import absolute_import
 import os
-import h5py
 import logging
 import numpy
 from .utils.logging import log_verbose
@@ -61,6 +60,7 @@ class SpikeManager:
 
     @classmethod
     def _read_spikes_sonata(cls, filename, population):
+        import h5py
         spikes_file = h5py.File(filename, "r")
         # File should have been validated earlier
         spikes = spikes_file.get("spikes/" + population)


### PR DESCRIPTION
## Context
"special" binaries which flushes denormal results to zero triggers the numpy warning for subnormal in every rank
after "import h5py". Neurodamus had a filter to ignore this type of warning, but it is insufficient after the recent change of adding "import h5py" at the top of replay.py. We have flooded warnings at the beginning of the simulation before instantiating neuron. This PR changes to import h5py in the function call to make the filter work again. It also ensures that we are loading the right h5py version.
 
## Scope
In replay.py, import h5py in the function call instead of at the top.

## Testing
Existing tests

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
