### PR TITLE
BBPBGLIB-1061 SONATA conf: Dont map to internal connectivity

### DIFF
--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -322,7 +322,7 @@ class ConnectionManagerBase(object):
 
     # - override if needed
     def _open_synapse_file(self, synapse_file, pop_name, n_nrn_files=None):
-        logging.info("Opening Synapse file %s, population: %s", synapse_file, pop_name)
+        logging.debug("Opening Synapse file %s, population: %s", synapse_file, pop_name)
         return self.SynapseReader.create(
             synapse_file, self.CONNECTIONS_TYPE, pop_name,
             n_nrn_files, self._raw_gids,  # Used eventually by NRN reader

--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -251,6 +251,9 @@ class SonataConfig:
             # respecting engine precedence
             # For edges to be considered inner connectivity they must be named "default"
             for edge_config in network.get("edges") or []:
+                if "nrnPath" in circuit_conf:
+                    break  # Already found
+
                 for edge_pop_name in edge_config["populations"].keys():
                     edge_storage = self.circuits.edge_population(edge_pop_name)
                     edge_type = self.circuits.edge_population_properties(edge_pop_name).type
@@ -265,9 +268,10 @@ class SonataConfig:
                             edges_file = os.path.join(os.path.dirname(self.network), edges_file)
                         edge_pop_path = edges_file + ":" + edge_pop_name
                         circuit_conf["nrnPath"] = edge_pop_path
-                    else:
-                        circuit_conf["nrnPath"] = False
+                        break
 
+            circuit_conf.setdefault("nrnPath", False)
+            logging.debug("Circuit config for node pop '%s': %s", node_pop_name, circuit_conf)
             return circuit_conf
 
         return {

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -528,9 +528,12 @@ class Node:
             c_target.population = self._circuits.alias.get(conf._name)
 
         edge_file, *pop = conf.get("nrnPath").split(":")
+        edge_pop = pop[0] if pop else None
         if not os.path.isabs(edge_file):
             edge_file = find_input_file(edge_file)
-        src, dst = edge_node_pop_names(edge_file, pop[0] if pop else None)
+        src, dst = edge_node_pop_names(edge_file, edge_pop)
+
+        logging.info("Processing edge file %s, pop: %s", edge_file, edge_pop)
 
         if src and dst and src != dst:
             raise ConfigurationError("Inner connectivity with different populations")

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -516,7 +516,7 @@ class Node:
         """
         log_stage("Circuit %s", conf._name or "(default)")
         if not conf.get("nrnPath"):
-            logging.info(" => Circuit internal connectivity has been DISABLED")
+            log_verbose(" => No internal connectivity")
             return
 
         if SimConfig.cli_options.restrict_connectivity >= 2:

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -516,7 +516,7 @@ class Node:
         """
         log_stage("Circuit %s", conf._name or "(default)")
         if not conf.get("nrnPath"):
-            log_verbose(" => No internal connectivity")
+            logging.info(" => No connectivity set as internal. See projections")
             return
 
         if SimConfig.cli_options.restrict_connectivity >= 2:

--- a/tests/test_synapses.py
+++ b/tests/test_synapses.py
@@ -343,7 +343,7 @@ def test_no_edge_creation(capsys):
     n.create_synapses()
 
     captured = capsys.readouterr()
-    assert "Circuit internal connectivity has been DISABLED" in captured.out
+    assert "No connectivity set as internal" in captured.out
     assert len(n.circuits.edge_managers) == 0
 
     os.unlink(tmp_config.name)


### PR DESCRIPTION
## Context

Address BBPBGLIB-1061 partially, ensuring, for the moment that we instantiate all projections.

## Scope
 - Consider only some specifically-named edge populations as internal connectivity
 - Other populations shall go as projections

Not all populations should go as projections since circuits still respect order, which is important for the case of e.g. NGV.

## Testing
Existing CI tests

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
