### PR TITLE
ci git clone set --depth=1

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install libsonatareport
       run: |
-        git clone https://github.com/BlueBrain/libsonatareport.git --recursive
+        git clone https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON ..
@@ -43,7 +43,7 @@ jobs:
         pip install -U pip setuptools
         pip install "cython<3" pytest sympy
         export SONATAREPORT_DIR=$(pwd)/libsonatareport/build/install
-        git clone https://github.com/neuronsimulator/nrn.git
+        git clone https://github.com/neuronsimulator/nrn.git --depth=1
         cd nrn
         mkdir build && cd build
         cmake -G Ninja -DPYTHON_EXECUTABLE=$(which python) -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_INTERVIEWS=OFF \


### PR DESCRIPTION
## Context
<!-- Please brifly describe the problem the PR solves and what the solution was -->

A small change. Cloning NEURON takes some time and space. This PR tells the CI workflow not to fetch the whole git history.

## Scope
<!--
Please describe in more detail the several changes implemented. How did we solve it?
E.g. change component-A to..., created a new data structure, etc...
-->
I just added `--depth=1` to git clone commands.

## Testing

Instead of `90k` it retrieves `3k` objects for NEURON.

### Before

```bash
Cloning into 'nrn'...                                                                                                                                                                                                                
remote: Enumerating objects: 90968, done. 
```

### After

```bash
Cloning into 'nrn'...                                                                                                                                                                                                                
remote: Enumerating objects: 2930, done.   
```               


## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
