### PR TITLE
Don't build containers unless we're on a tagged commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ configure-docker-image:
     reports:
       dotenv: build.env
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG
     - if: $CI_PIPELINE_SOURCE == "web"
 
 build-docker-image:
@@ -166,7 +166,7 @@ build-docker-image:
     -   echo "Building"
     - fi
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG
     - if: $CI_PIPELINE_SOURCE == "web"
 
 upload-to-docker-hub:
@@ -199,7 +199,7 @@ upload-to-docker-hub:
     - podman --log-level=debug push ${CI_REGISTRY_IMAGE}:${REGISTRY_IMAGE_TAG} docker://docker.io/bluebrain/${HUB_REPO_NAME}:${REGISTRY_IMAGE_TAG}
     - podman --log-level=debug push ${CI_REGISTRY_IMAGE}:${REGISTRY_IMAGE_TAG} docker://docker.io/bluebrain/${HUB_REPO_NAME}:latest
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_TAG
     - if: $CI_PIPELINE_SOURCE == "web"
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,6 +187,7 @@ upload-to-docker-hub:
   rules:
     - if: $CI_COMMIT_TAG
     - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
 
 
 # The following stages are overrides. Don't rename

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,20 +77,6 @@ configure-docker-image:
     - apt-get update -y
     - apt-get install -y git skopeo python3
     - |
-      echo "Checking whether we're on a tagged commit"
-      set +e
-      git describe --tags --exact-match
-      if [[ $? -ne 0 ]]; then
-          echo "Not a tagged commit - skipping container build"
-          BUILD_DOCKER_CONTAINER="false"
-          cat <<EOF > build.env
-          BUILD_DOCKER_CONTAINER=$BUILD_DOCKER_CONTAINER
-          EOF
-          cat build.env
-          exit 0
-      fi
-      set -e
-    - |
       echo "Getting package version and checking whether we need to build the container"
       PACKAGE_VERSION=$(git describe --tags)
       REGISTRY_IMAGE_TAG=$(echo ${PACKAGE_VERSION%-*} | sed 's/-/.dev/')

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,20 @@ configure-docker-image:
     - apt-get update -y
     - apt-get install -y git skopeo python3
     - |
+      echo "Checking whether we're on a tagged commit"
+      set +e
+      git describe --tags --exact-match
+      if [[ $? -ne 0 ]]; then
+          echo "Not a tagged commit - skipping container build"
+          BUILD_DOCKER_CONTAINER="false"
+          cat <<EOF > build.env
+          BUILD_DOCKER_CONTAINER=$BUILD_DOCKER_CONTAINER
+          EOF
+          cat build.env
+          exit 0
+      fi
+      set -e
+    - |
       echo "Getting package version and checking whether we need to build the container"
       PACKAGE_VERSION=$(git describe --tags)
       REGISTRY_IMAGE_TAG=$(echo ${PACKAGE_VERSION%-*} | sed 's/-/.dev/')

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,6 +129,7 @@ configure-docker-image:
       dotenv: build.env
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_PIPELINE_SOURCE == "web"
 
 build-docker-image:
   timeout: 2h
@@ -166,6 +167,7 @@ build-docker-image:
     - fi
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_PIPELINE_SOURCE == "web"
 
 upload-to-docker-hub:
   image: ubuntu:22.04
@@ -198,6 +200,7 @@ upload-to-docker-hub:
     - podman --log-level=debug push ${CI_REGISTRY_IMAGE}:${REGISTRY_IMAGE_TAG} docker://docker.io/bluebrain/${HUB_REPO_NAME}:latest
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_PIPELINE_SOURCE == "web"
 
 
 # The following stages are overrides. Don't rename


### PR DESCRIPTION
## Context
We're getting dev build containers on main, where we only want actual version containers.

Todo:
* [x] `CI_COMMIT_BRANCH` is only available in branch pipelines, not on tag pipelines
* [x] We should probably trigger explicitly on tag creation (update the webhook)

Webhook was upated - I tried on a private repository first, sync with gitlab didn't break there.

Building containers manually for older tags throught he pipeline is not possible (the pipeline configuration just wasn't there), that will only be possible once everything is in place.

## Scope
This PR will check whether we're on a tagged commit before building the docker container. If not, we don't build the container.

## Testing
N/A

## Review
* [x] PR description is complete
* ~~[ ] Coding style (imports, function length, New functions, classes or files) are good~~
* ~~[ ] Unit/Scientific test added~~
* ~~[ ] Updated Readme, in-code, developer documentation~~
