### PR TITLE
protect numpy.concatenate empty tuple in get_local_gids

### DIFF
--- a/neurodamus/target_manager.py
+++ b/neurodamus/target_manager.py
@@ -545,7 +545,7 @@ class NodesetTarget(_TargetInterface, _HocTargetInterface):
         else:
             gids_groups = tuple(pop_gid_intersect(ns) for ns in self.nodesets)
 
-        return numpy.concatenate(gids_groups)
+        return numpy.concatenate(gids_groups) if gids_groups else numpy.empty(0)
 
     def getPointList(self, cell_manager, **kw):
         """ Retrieve a TPointList containing compartments (based on section type and

--- a/tests/test_nodeset_target.py
+++ b/tests/test_nodeset_target.py
@@ -1,10 +1,9 @@
 import numpy
 
-from neurodamus.core.nodeset import NodeSet
-from neurodamus.target_manager import NodesetTarget
-
 
 def test_get_local_gids():
+    from neurodamus.core.nodeset import NodeSet
+    from neurodamus.target_manager import NodesetTarget
     nodes_popA = NodeSet([1, 2]).register_global("pop_A")
     nodes_popB = NodeSet([1, 2]).register_global("pop_B")
     local_gids = [NodeSet([1]).register_global("pop_A"), NodeSet([2]).register_global("pop_B")]

--- a/tests/test_nodeset_target.py
+++ b/tests/test_nodeset_target.py
@@ -1,0 +1,18 @@
+import numpy
+
+from neurodamus.core.nodeset import NodeSet
+from neurodamus.target_manager import NodesetTarget
+
+
+def test_get_local_gids():
+    nodes_popA = NodeSet([1, 2]).register_global("pop_A")
+    nodes_popB = NodeSet([1, 2]).register_global("pop_B")
+    local_gids = [NodeSet([1]).register_global("pop_A"), NodeSet([2]).register_global("pop_B")]
+    t1 = NodesetTarget("t1", [nodes_popA], local_gids)
+    t2 = NodesetTarget("t2", [nodes_popB], local_gids)
+    t_empty = NodesetTarget("t_empty", [], local_gids)
+    numpy.testing.assert_array_equal(t1.get_local_gids(), [1])
+    numpy.testing.assert_array_equal(t1.get_local_gids(raw_gids=True), [1])
+    numpy.testing.assert_array_equal(t2.get_local_gids(), [1002])
+    numpy.testing.assert_array_equal(t2.get_local_gids(raw_gids=True), [2])
+    numpy.testing.assert_array_equal(t_empty.get_local_gids(), [])


### PR DESCRIPTION
## Context
Seen in some simulations, when a NodeSet taget doesn't contain any cell by its (bad) definition, `get_local_gids` raises an error from `numpy.concatenate(tuple([]))`. This PR sets an protection for this case.

## Scope
In the definition of `NodesetTarget::get_local_gids`, return `numpy.empty(0)` if the array to be concatenated is empty

## Testing
A new unit test `test_nodeset_target.py`

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
