### PR TITLE
Run the simulation test nightly instead of on PRs and main

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -1,16 +1,8 @@
 name: neurodamus build and test
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - '**.rst'
-      - 'docs/**'
-      - 'docker/**'
+  schedule:
+    # every evening at 20:00 UTC
+    - cron: '0 20 * * *'
 
 jobs:
   simulation:


### PR DESCRIPTION
## Context
Running the simulation workflow on pull request was deemed overkill in the neurodamus sync, so we're moving it to a nightly run.

## Scope
Changed workflow trigger - if necessary it can still be adjusted.

## Testing
n/a

## Review
* [x] PR description is complete
* ~~[ ] Coding style (imports, function length, New functions, classes or files) are good~~
* ~~[ ] Unit/Scientific test added~~
* ~~[ ] Updated Readme, in-code, developer documentation~~
