### PR TITLE
[HPCTM-1824] Introducing a temporary set for faster lookup in the src_target gids

### DIFF
--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -752,7 +752,7 @@ class ConnectionManagerBase(object):
             else self._populations.values()
 
         # temporary set for faster lookup
-        src_gids = set(src_target.get_gids())
+        src_gids = src_target and set(src_target.get_gids())
         for population in populations:
             logging.debug("Connections from population %s", population)
             tgids = numpy.fromiter(population.target_gids(), 'uint32')

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -748,6 +748,8 @@ class ConnectionManagerBase(object):
         populations: List[ConnectionSet] = (conn_population,) if conn_population is not None \
             else self._populations.values()
 
+        # temporary set for faster lookup
+        src_gids = set(src_target.get_gids())
         for population in populations:
             logging.debug("Connections from population %s", population)
             tgids = numpy.fromiter(population.target_gids(), 'uint32')
@@ -755,7 +757,7 @@ class ConnectionManagerBase(object):
             if selected_gids:
                 tgids = numpy.intersect1d(tgids, selected_gids + tgid_offset)
             for conn in population.get_connections(tgids):
-                if src_target is None or conn.sgid in src_target:
+                if src_target is None or conn.sgid in src_gids:
                     yield conn
 
     # -

--- a/neurodamus/core/nodeset.py
+++ b/neurodamus/core/nodeset.py
@@ -7,8 +7,6 @@ import numpy
 from ..utils import compat, WeakList
 from . import MPI
 
-import logging
-
 
 class PopulationNodes:
     """
@@ -277,8 +275,6 @@ class SelectionNodeSet(_NodeSetBase):
         return self._size
 
     def raw_gids(self):
-        if len(self) > 1e6:
-            logging.warning("Large dataset. Consider using raw_gids_iter")
         return numpy.add(self._selection.flatten(), 1, dtype="uint32")
 
     def raw_gids_iter(self):


### PR DESCRIPTION
## Context
Addresses HPCTM-1824 and HPCTM-1770.

During the synapse configure, a numpy array was created with the gids of the src_target nodeset for every connection. Then a numpy.searchsorted was checking if a certain gid was in that array. This was taking a long time (~1h) when having a lot of connections (~2e8).
The idea is to create a set with the target gids in order to improve the lookup time.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
