### PR TITLE
[BBPBGLIB-1055] Support "<NONE>" as nrnPath

### DIFF
--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -544,6 +544,9 @@ def _make_circuit_config(config_dict, req_morphology=True):
         config_dict["MorphologyPath"] = False
     elif config_dict.get("nrnPath") == "<NONE>":
         config_dict["nrnPath"] = False
+        if config_dict.get("CellLibraryFile", "start.ncs") == "start.ncs":
+            raise ConfigurationError(
+                "ncs circuits don't support disabling connectivity with nrnPath='<NONE>'")
     _validate_circuit_morphology(config_dict, req_morphology)
     _validate_file_extension(config_dict.get("CellLibraryFile"))
     _validate_file_extension(config_dict.get("nrnPath"))

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -383,9 +383,13 @@ class Node:
             return None
 
         # Build load balancer as per requested options
-        # Compat Note: data_src in BlueConfig mode was the nrnPath. Not anymore.
+        # Compat Note:
+        # data_src in BlueConfig mode was the nrnPath. Not anymore (except if not defined or <NONE>)
         prosp_hosts = self._run_conf.get("ProspectiveHosts")
-        data_src = circuit.CircuitPath if is_sonata_config else self._run_conf["nrnPath"]
+        data_src = (
+            circuit.CircuitPath if is_sonata_config
+            else self._run_conf["nrnPath"] or circuit.CircuitPath
+        )
         load_balancer = LoadBalance(lb_mode, data_src, self._target_manager, prosp_hosts)
 
         if load_balancer.valid_load_distribution(target_spec):


### PR DESCRIPTION
## Context
The simulation was crashing in certain situations when using nrnPath="<NONE>", specifically in the load balancing and loading nodes in a ncs circuit.

To avoid this in the load balancing, we use the CircuitPath instead.
When using ncs circuits, we raise an ConfigurationError exception at the beginning of the simulation.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
