### PR TITLE
Remove misleading warning.

### DIFF
--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -372,12 +372,6 @@ class Node:
         target = self.target_manager.get_target(target_spec)
         cell_count = None
 
-        if not target.is_void():
-            cell_count = target.gid_count()
-            if cell_count > 100 * MPI.size:
-                logging.warning("Your simulation has a very high count of cells per CPU. "
-                                "Please consider launching it in a larger MPI cluster")
-
         # Check / set load balance mode
         lb_mode = LoadBalance.select_lb_mode(SimConfig, self._run_conf, target)
         if lb_mode == LoadBalanceMode.RoundRobin:


### PR DESCRIPTION
The warning is misleading and causes users to run simulation with more than 10x too many resources. Since the magic cutoff is neither a lower bound, nor an upper bound (by many orders of magnitude), we should simply not print anything.