### PR TITLE
BBPBGLIB-1076 Make all edge managers set load_offsets at init

### DIFF
--- a/neurodamus/morphio_wrapper.py
+++ b/neurodamus/morphio_wrapper.py
@@ -209,11 +209,8 @@ class MorphIOWrapper:
                 'A H5 file morphology is not supposed to have a soma of type: {}'.format(
                     self._morph.soma_type))
         logging.debug(
-            "({}, {}, {}) has soma type : {}",
-            self._collection_dir,
-            self._morph_name,
-            self._morph_ext,
-            self._morph.soma_type
+            "(%s, %s, %s) has soma type : %s",
+            self._collection_dir, self._morph_name, self._morph_ext, self._morph.soma_type
         )
 
         if self._morph.soma_type == SomaType.SOMA_SINGLE_POINT:

--- a/neurodamus/ngv.py
+++ b/neurodamus/ngv.py
@@ -346,6 +346,10 @@ class NeuroGliaConnManager(ConnectionManagerBase):
     conn_factory = NeuroGlialConnection
     SynapseReader = NeuroGlialSynapseReader
 
+    def __init__(self, circuit_conf, target_manager, cell_manager, src_cell_manager=None, **kw):
+        kw.pop("load_offsets")
+        super().__init__(circuit_conf, target_manager, cell_manager, src_cell_manager, **kw)
+
     def _add_synapses(self, cur_conn, syns_params, syn_type_restrict=None, base_id=0):
         for syn_params in syns_params:
             cur_conn.add_synapse(None, syn_params)

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -512,7 +512,7 @@ class Node:
 
         log_stage("Handling projections...")
         for pname, projection in SimConfig.projections.items():
-            self._load_projections(pname, projection, dry_run_stats=self._dry_run_stats)
+            self._load_projections(pname, projection, **manager_kwa)
 
         if SimConfig.dry_run:
             self.syn_total_memory = self._dry_run_stats.collect_display_syn_counts()


### PR DESCRIPTION
## Context
Even with a small execution we were hitting
```
323 NEURON: gid=1000000 already exists on this process as an output port
```
When outputting some debug it turned out that the post synaptic edge index was not being taken into account for the NGV netcon id. Therefore the id collision was almost certain.

## The problem

Turns out the `load_offset` property was not always set to True in the connection manager. 

This likely happens since in newer Sonata circuits there might be no internal connectivity, where such setting was being applied.

## Solution

With the current readers we always have synapse ids. So we could generalize the concept and set
 - All managers to load their synapse indices (ctor arg)
 - All except NGV which will never require them, so we explicitly disabled.
 - Setting applied even for connection managers holding projections only

## Testing

Tested with Katta's small NGV circuit.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
