### PR TITLE
Manual container versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,14 @@ variables:
   BLUECONFIGS_BRANCH:
     value: $BLUECONFIGS_BRANCH
     description: 'Name of the blueconfigs branch to test against'
+  LIBSONATAREPORT_TAG:
+    description: git tag for libsonata-report
+  LIBSONATA_TAG:
+    description: git tag for libsonata
+  NEURON_COMMIT_ID:
+    description: commit ID for neuron
+  REGISTRY_IMAGE_TAG:
+    description: this will be the container version - mandatory if you specify one of LIBSONATAREPORT_TAG, LIBSONATA_TAG, NEURON_COMMIT_ID
 
 python3-base:
   extends: .tox-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,14 +23,6 @@ variables:
   BLUECONFIGS_BRANCH:
     value: $BLUECONFIGS_BRANCH
     description: 'Name of the blueconfigs branch to test against'
-  LIBSONATAREPORT_TAG:
-    description: git tag for libsonata-report
-  LIBSONATA_TAG:
-    description: git tag for libsonata
-  NEURON_COMMIT_ID:
-    description: commit ID for neuron
-  REGISTRY_IMAGE_TAG:
-    description: this will be the container version - mandatory if you specify one of LIBSONATAREPORT_TAG, LIBSONATA_TAG, NEURON_COMMIT_ID
 
 python3-base:
   extends: .tox-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,6 +166,10 @@ build-docker-image:
       --build-arg LIBSONATA_TAG="$LIBSONATA_TAG"
       --build-arg NEURON_COMMIT_ID="$NEURON_COMMIT_ID"
   before_script:
+    - echo "LIBSONATAREPORT_TAG is .$LIBSONATAREPORT_TAG."
+    - echo "LIBSONATA_TAG is .$LIBSONATA_TAG."
+    - echo "NEURON_COMMIT_ID is .$NEURON_COMMIT_ID."
+    - echo "REGISTRY_IMAGE_TAG is .$REGISTRY_IMAGE_TAG."
     - set -x
     - if [ "$BUILD_DOCKER_CONTAINER" == "false" ]; then
     -   echo "No need to build the docker container"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,8 +80,14 @@ configure-docker-image:
     - apt-get install -y git skopeo python3
     - |
       echo "Getting package version and checking whether we need to build the container"
-      PACKAGE_VERSION=$(git describe --tags)
-      REGISTRY_IMAGE_TAG=$(echo ${PACKAGE_VERSION%-*} | sed 's/-/.dev/')
+      if [ -n "${LIBSONATAREPORT_TAG}" || -n "${LIBSONATA_TAG}" || -n "${NEURON_COMMIT_ID}" && -z "${REGISTRY_IMAGE_TAG}" ]; then
+        echo "If you specify LIBSONATAREPORT_TAG, LIBSONATA_TAG or NEURON_COMMIT_ID, you must also specify REGISTRY_IMAGE_TAG."
+        exit 1
+      fi
+      if [ -z "${REGISTRY_IMAGE_TAG}" ]; then
+        PACKAGE_VERSION=$(git describe --tags)
+        REGISTRY_IMAGE_TAG=$(echo ${PACKAGE_VERSION%-*} | sed 's/-/.dev/')
+      fi
       set +e
       skopeo inspect docker://bluebrain/neurodamus:${REGISTRY_IMAGE_TAG}
       if [[ $? -eq 0 ]]; then
@@ -97,9 +103,15 @@ configure-docker-image:
       git clone https://github.com/bluebrain/spack
       cd spack
       source ./share/spack/setup-env.sh
-      LIBSONATAREPORT_TAG=$(spack info libsonata-report | awk 'matched{print $NF;matched=0} /Preferred/{matched=1}')
-      LIBSONATA_TAG=v$(spack info py-libsonata | awk 'matched{print $1;matched=0} /Preferred/{matched=1}')
-      NEURON_COMMIT_ID=$(spack info neuron | awk 'matched{print $NF;matched=0} /Preferred/{matched=1}')
+      if [ -z "${LIBSONATAREPORT_TAG}" ]; then
+        LIBSONATAREPORT_TAG=$(spack info libsonata-report | awk 'matched{print $NF;matched=0} /Preferred/{matched=1}')
+      fi
+      if [ -z "${LIBSONATA_TAG}" ]; then
+        LIBSONATA_TAG=v$(spack info py-libsonata | awk 'matched{print $1;matched=0} /Preferred/{matched=1}')
+      fi
+      if [ -z "${NEURON_COMMIT_ID}" ]; then
+        NEURON_COMMIT_ID=$(spack info neuron | awk 'matched{print $NF;matched=0} /Preferred/{matched=1}')
+      fi
       cd ..
     - |
       cat <<EOF > build.env

--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,8 @@ Building the docker container
 The docker container image is built automatically when a new tag is created in the repository, if a container with the specified version doesn't already exist.
 On manual pipeline runs, the container image is also built but not automatically pushed to docker-hub; you'll have to manually start the job in the pipeline you created if you want this to happen. Keep in mind that this is *optional*, the container image is *always* pushed to the gitlab registry!
 
+The docker images will be built in the `regular gitlab pipeline <https://bbpgitlab.epfl.ch/hpc/sim/neurodamus/-/pipelines>`_ - if triggered under the right conditions (either manually or through git tag creation) the container jobs will be added to this pipeline.
+
 If you run the pipeline manually, you can also set versions for the dependencies:
   * `LIBSONATAREPORT_TAG`: git tag for libsonata-report
   * `LIBSONATA_TAG`: git tag for libsonata

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,18 @@ Alternatively, you can start directly a neurodamus docker container where all th
 With the container, you can build your mod files and run simulations.
 See instructions in `docker/README.md <https://github.com/BlueBrain/neurodamus/blob/main/docker/README.md>`_.
 
+Building the docker container
+-----------------------------
+The docker container image is built automatically when a new tag is created in the repository, if a container with the specified version doesn't already exist.
+On manual pipeline runs, the container image is also built but not automatically pushed to docker-hub; you'll have to manually start the job in the pipeline you created if you want this to happen.
+
+If you run the pipeline manually, you can also set versions for the dependencies:
+  * `LIBSONATAREPORT_TAG`: git tag for libsonata-report
+  * `LIBSONATA_TAG`: git tag for libsonata
+  * `NEURON_COMMIT_ID`: commit ID for neuron
+  * `REGISTRY_IMAGE_TAG`: this will be the container version
+
+
 Acknowledgment
 ==============
 The development of this software was supported by funding to the Blue Brain Project,

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ If you run the pipeline manually, you can also set versions for the dependencies
   * `LIBSONATAREPORT_TAG`: git tag for libsonata-report
   * `LIBSONATA_TAG`: git tag for libsonata
   * `NEURON_COMMIT_ID`: commit ID for neuron
-  * `REGISTRY_IMAGE_TAG`: this will be the container version
+  * `REGISTRY_IMAGE_TAG`: this will be the container version. Must be specified if you specify one of the others.
 
 
 Acknowledgment

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ See instructions in `docker/README.md <https://github.com/BlueBrain/neurodamus/b
 Building the docker container
 -----------------------------
 The docker container image is built automatically when a new tag is created in the repository, if a container with the specified version doesn't already exist.
-On manual pipeline runs, the container image is also built but not automatically pushed to docker-hub; you'll have to manually start the job in the pipeline you created if you want this to happen.
+On manual pipeline runs, the container image is also built but not automatically pushed to docker-hub; you'll have to manually start the job in the pipeline you created if you want this to happen. Keep in mind that this is *optional*, the container image is *always* pushed to the gitlab registry!
 
 If you run the pipeline manually, you can also set versions for the dependencies:
   * `LIBSONATAREPORT_TAG`: git tag for libsonata-report


### PR DESCRIPTION
## Context
Containers automatically take a specific version of libsonata, libsonata-report and neuron. Sometimes a user wants to build with a specific version of one or more of these dependencies.

## Scope
* Allow setting the variables that determine which dependency version to use manually
* If set, also require a container version to be specified to avoid "polluting" the official container builds

## Testing

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
