### PR TITLE
Workflow rule: CI_COMMIT_TAG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ workflow:
     - if: '$CI_EXTERNAL_PULL_REQUEST_IID'
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
     - if: $CI_PIPELINE_SOURCE == "web"
+      # Run workflows on tag creation to build the container
     - if: $CI_COMMIT_TAG
 
 variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ workflow:
     - if: '$CI_EXTERNAL_PULL_REQUEST_IID'
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
     - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_COMMIT_TAG
 
 variables:
   BLUECONFIGS_BRANCH:


### PR DESCRIPTION
## Context
Gitlab workflows were not triggering on tag creation.

## Scope
The job rules were correct, but the workflow rule for this scenario was missing.

## Testing


## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
