### PR TITLE
[BBPP134-1022] Handling exceptions from NEURON during emodel loading

### DIFF
--- a/neurodamus/metype.py
+++ b/neurodamus/metype.py
@@ -134,7 +134,8 @@ class METype(BaseCell):
         pass
 
     def __del__(self):
-        self._cellref.clear()  # cut cyclic reference
+        if self._cellref:
+            self._cellref.clear()  # cut cyclic reference
 
 
 class Cell_V6(METype):
@@ -163,8 +164,8 @@ class Cell_V6(METype):
             self._cellref = EModel(gid, morpho_path, morpho_file, *add_params)
             Nd.pc.mpiabort_on_error(old_flag)
         except Exception as e:
-            raise Exception("Error when loading Gid %d: emodel: %s, Morphology: %s"
-                            % (gid, emodel, morpho_file)) from e
+            raise RuntimeError("Error from NEURON when loading Gid %d: emodel: %s, Morphology: %s"
+                               ": %s" % (gid, emodel, morpho_file, str(e))) from e
         self._ccell = self._cellref
         self._synapses = Nd.List()
         self._syn_helper_list = Nd.List()

--- a/neurodamus/metype.py
+++ b/neurodamus/metype.py
@@ -156,7 +156,15 @@ class Cell_V6(METype):
         add_params = meinfos_v6.add_params or (keep_axon,)  # Keep axon incompatible with add_params
 
         logging.debug("Loading Gid %d: emodel: %s, Morphology: %s", gid, emodel, morpho_file)
-        self._cellref = EModel(gid, morpho_path, morpho_file, *add_params)
+        try:
+            # For this step, do not call mpi_abort in neuron and let neurodamus handle and abort,
+            # NB: Do not re-raise as ConfigurationError, neurodamus doesn't call mpi_abort so hangs
+            old_flag = Nd.pc.mpiabort_on_error(0)
+            self._cellref = EModel(gid, morpho_path, morpho_file, *add_params)
+            Nd.pc.mpiabort_on_error(old_flag)
+        except Exception as e:
+            raise Exception("Error when loading Gid %d: emodel: %s, Morphology: %s"
+                            % (gid, emodel, morpho_file)) from e
         self._ccell = self._cellref
         self._synapses = Nd.List()
         self._syn_helper_list = Nd.List()
@@ -203,7 +211,15 @@ class Cell_V5(METype):
         """
         EModel = getattr(Nd, emodel)
         logging.debug("Loading Gid %d: emodel: %s", gid, emodel)
-        self._ccell = ccell = EModel(gid, morpho_path)
+        try:
+            # For this step, do not call mpi_abort in neuron and let neurodamus handle and abort,
+            # NB: Do not re-raise as ConfigurationError, neurodamus doesn't call mpi_abort so hangs
+            old_flag = Nd.pc.mpiabort_on_error(0)
+            self._ccell = ccell = EModel(gid, morpho_path)
+            Nd.pc.mpiabort_on_error(old_flag)
+        except Exception as e:
+            raise Exception("Error when loading Gid %d: emodel: %s, morpho_path: %s"
+                            % (gid, emodel, morpho_path)) from e
         self._cellref = ccell.CellRef
         self._synapses = ccell.CellRef.synlist
         self._syn_helper_list = ccell.CellRef.synHelperList

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,17 @@
+import pytest
+from pathlib import Path
+
+
+USECASE3 = Path(__file__).parent.absolute() / "simulations" / "usecase3"
+SONATA_CONF_FILE = str(USECASE3 / "simulation_sonata.json")
+
+
+def test_handling_neuron_exceptions():
+    from neurodamus import Node
+    n = Node(SONATA_CONF_FILE)
+    n.load_targets()
+    n._extra_circuits['NodeA'].MorphologyPath = str(USECASE3 / "dummy_err_dir")
+    with pytest.raises(RuntimeError,
+                       match="Error from NEURON when loading Gid .: emodel: .*, Morphology: .*: "
+                             "hocobj_call error: hoc_execerror: .*:file is not open"):
+        n.create_cells()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,9 +1,18 @@
+import os
 import pytest
 from pathlib import Path
 
 
 USECASE3 = Path(__file__).parent.absolute() / "simulations" / "usecase3"
 SONATA_CONF_FILE = str(USECASE3 / "simulation_sonata.json")
+
+pytestmark = [
+    pytest.mark.forked,
+    pytest.mark.skipif(
+        not os.environ.get("NEURODAMUS_NEOCORTEX_ROOT"),
+        reason="Test requires loading a neocortex model to run"
+    )
+]
 
 
 def test_handling_neuron_exceptions():


### PR DESCRIPTION
## Context
The current error handling between Neuron and neurodamus is as such:
* For a single process, Neuron (`hoc_execerror_mes`) throws a RuntimeError and neurodamus handles it (in `commands.py`) and aborts the process.
* For multiple processes, Neuron calls `nrnmpi_abort` when an error is raised in any rank. The exception can not be caught in neurodamus before the processes end.

As meaningful error msg is  requested in [BBPP134-1022], this PR sets Neuron not call `nrnmpi_abort` internally but passes the exception to be handled later in neurodamus.

## Scope
In `metype.py`, set the flag `old_flag = Nd.pc.mpiabort_on_error(0)` before the neuron process and revert it afterwards. When an exception from Neuron is caught by neurodamus, neurodamus will improve the error msg with more details and raise again.

## Testing
New unit test `test_error_handling.py`

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
