### PR TITLE
Use default dt value of NEURON in WholeCell load balancing

### DIFF
--- a/neurodamus/core/_neuron.py
+++ b/neurodamus/core/_neuron.py
@@ -8,6 +8,7 @@ import os.path
 from contextlib import contextmanager
 from .configuration import NeuronStdrunDefaults
 from .configuration import GlobalConfig
+from .configuration import SimConfig
 from ..utils import classproperty
 
 
@@ -241,10 +242,16 @@ class MComplexLoadBalancer(object):
 
     @staticmethod
     def _create_mcomplex():
+        # Save the dt of the simulation and set the dt for calculating the ExperimentalMechComplex
+        # to the default value of 0.025
+        prev_dt = Neuron.h.dt
+        Neuron.h.dt = SimConfig.default_neuron_dt
         # ExperimentalMechComplex is a complex routine changing many state vars, and cant be reused
         # Therefore here we create a temporary LoadBalance obj
         lb = Neuron.h.LoadBalance()
         lb.ExperimentalMechComplex("StdpWA", "extracel", "HDF5", "Report", "Memory", "ASCII")
+        # Revert dt to the old value
+        Neuron.h.dt = prev_dt
         # mcomplex changes neuron state and results get different. We re-init
         Neuron.h.init()
 

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -213,6 +213,7 @@ class _SimConfig(object):
     # In principle not all vars need to be required as they'r set by the parameter functions
     blueconfig_dir = None
     current_dir = None
+    default_neuron_dt = 0.025
     buffer_time = 25
     save = None
     save_time = None
@@ -626,7 +627,8 @@ def _global_parameters(config: _SimConfig, run_conf):
     h.celsius = config.celsius
     h.set_v_init(config.v_init)
     h.tstop = config.tstop
-    h.dt = run_conf.get("Dt", 0.025)
+    config.default_neuron_dt = h.dt
+    h.dt = run_conf.get("Dt", h.dt)
     h.steps_per_ms = 1.0 / h.dt
     props = ("celsius", "v_init", "extracellular_calcium", "tstop", "buffer_time")
     log_verbose("Global params: %s",

--- a/tests/test_loadbalance.py
+++ b/tests/test_loadbalance.py
@@ -158,8 +158,6 @@ def test_loadbal_integration():
     GlobalConfig.verbosity = 2
     config_file = str(SIM_DIR / "usecase3" / "simulation_sonata.json")
     nd = Node(config_file, {"lb_mode": "WholeCell"})
-    from neuron import h
-    h.dt = 0.025  # LoadBalance requires this ATM
     nd.load_targets()
     lb = nd.compute_load_balance()
     nd.create_cells(lb)


### PR DESCRIPTION
Save the default `dt` from `NEURON` and use it when generating the `mcomplex` file with `ExperimentalMechComplex`

## Context
This PR solves the issue described in https://github.com/neuronsimulator/nrn/issues/2038

## Scope
First we save the original `dt` value of `NEURON` in the `SimConfig`. Then in the function that generates the complexity of each cell we set the `dt` to the original `NEURON` value, which normally should be `0.025`.

## Testing
Removed the explicit setting of `dt` to `0.025` in the load balance unit test

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
