### PR TITLE
Fix docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents
    Module Reference <api/modules>
    Developer Documentation <architecture>
    Developing a Custom Neurodamus <development>
+   Online LFP Calculation <online-lfp>
 
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,6 @@ Contents
    Module Reference <api/modules>
    Developer Documentation <architecture>
    Developing a Custom Neurodamus <development>
-   Online LFP Calculation <online-lfp>
 
 
 Indices and tables

--- a/docs/online-lfp.rst
+++ b/docs/online-lfp.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 =======================================
 Online LFP Calculation Documentation
 =======================================
@@ -8,7 +10,7 @@ Electrodes Input File
 Required Format
 ~~~~~~~~~~~~~~~~
 
-To perform online LFP calculation, a weights file is required. The weights file should follow a specific format to ensure proper functioning. 
+To perform online LFP calculation, a weights file is required. The weights file should follow a specific format to ensure proper functioning.
 More information about this file can be found in the `SONATA Simulation Specification <https://github.com/BlueBrain/sonata-extension/blob/master/source/sonata_tech.rst#format-of-the-electrodes_file>`_
 
 Generating the Electrodes File

--- a/tox.ini
+++ b/tox.ini
@@ -63,4 +63,4 @@ setenv =
     PYTHONPATH = {toxinidir}
     PIP_INDEX_URL = https://bbpteam.epfl.ch/repository/devpi/simple
 commands =
-    sphinx-build docs docs/_build
+    sphinx-build -T -W docs docs/_build


### PR DESCRIPTION
## Context
readthedocs builds were failing due to a new file that was not referred to anywhere.
Additionally, pre-merge test builds didn't show this.

## Scope
* Included online-lfp in the main table of contents
* Updated tox.ini with `-W -T` flags:
   * `-W` to turn warnings into errors
   * `-T` to show full traceback on exceptions

## Testing
n/a

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
