### PR TITLE
Fix bug with duplicate count of synapses

### DIFF
--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -18,7 +18,7 @@ from .connection import Connection, ReplayMode
 from .io.synapse_reader import SynapseReader
 from .target_manager import TargetManager, TargetSpec
 from .utils import compat, bin_search, dict_filter_map
-from .utils.logging import log_verbose, log_all
+from .utils.logging import VERBOSE_LOGLEVEL, log_verbose, log_all
 from .utils.memory import DryRunStats
 from .utils.timeit import timeit
 
@@ -535,6 +535,7 @@ class ConnectionManagerBase(object):
         """
         if SimConfig.dry_run:
             counts = self._get_conn_stats(self._src_target_filter, None)
+            log_all(VERBOSE_LOGLEVEL, "Synapse count: %d", sum(counts.values()))
             self._dry_run_stats.synapse_counts += counts
             return
 
@@ -575,6 +576,8 @@ class ConnectionManagerBase(object):
 
         if SimConfig.dry_run:
             counts = self._get_conn_stats(src_target, dst_target)
+            count_sum = sum(counts.values())
+            log_all(VERBOSE_LOGLEVEL, "%s -> %s: %d", pop.src_name, conn_destination, count_sum)
             self._dry_run_stats.synapse_counts += counts
             return
 

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -276,7 +276,7 @@ class ConnectionManagerBase(object):
         self._load_offsets = kw.get("load_offsets", False)
         # An internal var to enable collection of synapse statistics to a Counter
         self._dry_run_stats: DryRunStats = kw.get("dry_run_stats")
-        self._dry_run_counted_cells = set()
+        self._dry_run_counted_cells = []
 
     def __str__(self):
         return "<{:s} | {:s} -> {:s}>".format(
@@ -728,10 +728,10 @@ class ConnectionManagerBase(object):
           -  We will only consider gids which have not been accounted for yet.
         """
         raw_gids = dst_target.get_local_gids(raw_gids=True) if dst_target else self._raw_gids
-        new_gids = numpy.array(list(set(raw_gids) - self._dry_run_counted_cells), dtype="uint32")
+        new_gids = numpy.setdiff1d(raw_gids, self._dry_run_counted_cells, assume_unique=True)
         if len(new_gids):
             counts = self._synapse_reader.get_counts(new_gids, group_by="syn_type_id")
-            self._dry_run_counted_cells.update(new_gids)
+            self._dry_run_counted_cells = numpy.union1d(self._dry_run_counted_cells, new_gids)
             return counts
         return {}
 

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -510,6 +510,7 @@ class Node:
             SynManagerCls = Engine.InnerConnectivityCls
             self._create_synapse_manager(SynManagerCls, circuit, target_manager, **manager_kwa)
 
+        MPI.check_no_errors()
         log_stage("Handling projections...")
         for pname, projection in SimConfig.projections.items():
             self._load_projections(pname, projection, **manager_kwa)

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -242,10 +242,10 @@ class DryRunStats:
         log_verbose("+{:=^68}+".format(" Synapse Count "))
         log_verbose("| {:^40s} | {:^10s} | {:^10s} |".format("Synapse Type", "Family", "Count"))
         log_verbose("+{:-^68}+".format(""))
-        for synapse_type, count in master_counter.items():
-            is_inh = synapse_type < 100
-            log_verbose("| {:40.0f} | {:<10s} | {:10.0f} |".format(
-                synapse_type, "INH" if is_inh else "EXC", count))
+        for syn_type, count in sorted(master_counter.items()):
+            is_inh = syn_type < 100
+            syn_type_str = "INH" if is_inh else "EXC"
+            log_verbose("| {:40.0f} | {:<10s} | {:10.0f} |".format(syn_type, syn_type_str, count))
             if is_inh:
                 inh_count += count
             else:


### PR DESCRIPTION
## Context
When using a different number of ranks it was noticeable a slightly different count in the number of synapses.

It turned out one was retrieving and counting synapses for the same gid under some circumstances when configure blocks would overlap.

## Scope
The bug is fixed by
 - keeping track of gids for which one has already retrieved synapse counts.
 - Exclude those when fetching and adding up the synapses counts per type to the global counter
 - Sort results order to improve comparison

## Testing
Running on a testing simulation 
 - 400 cells and 18 Configure blocks  (sonata-quick-v5-plasticity)
 - 1 vs 40 ranks (previously results would be different)

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
