### PR TITLE
Implement chunking mechanism for loading synapses in dryrun mode

### DIFF
--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -730,7 +730,7 @@ class ConnectionManagerBase(object):
           - _src target is not considered so we count all inbound synapses
           -  We will only consider gids which have not been accounted for yet.
         """
-        BLOCK_LENGTH = 5000
+        INITIAL_BLOCK_LENGTH = 5000
         SAMPLE_SIZE = 100
         raw_gids = dst_target.get_local_gids(raw_gids=True) if dst_target else self._raw_gids
         new_gids = numpy.setdiff1d(raw_gids, self._dry_run_counted_cells, assume_unique=True)
@@ -738,8 +738,8 @@ class ConnectionManagerBase(object):
             return {}
 
         temp_counter = Counter()
-        chunking_gen = gen_ranges(len(new_gids), BLOCK_LENGTH)
-        n_blocks = ceil(len(new_gids)/BLOCK_LENGTH)
+        chunking_gen = gen_ranges(len(new_gids), INITIAL_BLOCK_LENGTH)
+        total_blocks = sum(1 for _ in gen_ranges(len(new_gids), INITIAL_BLOCK_LENGTH))
         total_measured_cells = 0
 
         src_pop = self._src_cell_manager.population_name
@@ -751,8 +751,8 @@ class ConnectionManagerBase(object):
             temp_counter.update(sample_counts)
             total_measured_cells += len(sample_gids)
 
-            if cycle > 10:
-                log_all(VERBOSE_LOGLEVEL, "Rank: %d, %.2f%%", MPI.rank, (cycle+1)/n_blocks*100)
+            if cycle > 5:
+                log_all(VERBOSE_LOGLEVEL, "Rank: %d, %.2f%%", MPI.rank, (cycle+1)/total_blocks*100)
 
         self._dry_run_counted_cells = numpy.union1d(self._dry_run_counted_cells, new_gids)
 

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -9,7 +9,6 @@ from collections import defaultdict, Counter
 from itertools import chain
 from os import path as ospath
 from typing import List, Optional
-from math import ceil
 
 from .core import NeurodamusCore as Nd
 from .core import ProgressBarRank0 as ProgressBar, MPI

--- a/neurodamus/utils/pyutils.py
+++ b/neurodamus/utils/pyutils.py
@@ -197,10 +197,11 @@ def append_recarray(target_array, record):
     return target_array
 
 
-def gen_ranges(limit, blocklen, low=0):
-    """Generates ranges in block intervals for a given length"""
-    for high in range(low + blocklen, limit, blocklen):
+def gen_ranges(limit, initial_blocklen, increment=1000, low=0):
+    """Generates ranges in block intervals for a given length with increasing block size."""
+    blocklen = initial_blocklen
+    while low < limit:
+        high = min(low + blocklen, limit)
         yield low, high
         low = high
-    if low < limit:
-        yield low, limit
+        blocklen += increment  # Increase the block length for the next iteration

--- a/neurodamus/utils/pyutils.py
+++ b/neurodamus/utils/pyutils.py
@@ -195,3 +195,12 @@ def append_recarray(target_array, record):
         target_array.resize(nrows+1, refcheck=False)
         target_array[nrows] = record
     return target_array
+
+
+def gen_ranges(limit, blocklen, low=0):
+    """Generates ranges in block intervals for a given length"""
+    for high in range(low + blocklen, limit, blocklen):
+        yield low, high
+        low = high
+    if low < limit:
+        yield low, limit


### PR DESCRIPTION
## Context
Up until now for the purposes of counting in the dry run mode, all synapses were loaded at the same time. This started to create some issues when moving to very large circuit where the execution would consistently run out of memory.

This MR tries to fix this issue by chunking the loading in blocks of 100 cells at a time in order not to spend the whole memory.

## Scope
The changes are relatively small and include the adding of a small generator for chunking ranges in the util section, and a small rework of the loading synapses block to load cells in predefined ranges.

## Testing
No new functionality so no new tests are necessary.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
