### PR TITLE
Update build_neurodamus.sh with `--only-neuron`

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -76,9 +76,7 @@ jobs:
         tar -xf O1_mods.xz
         cp -r mod tests/share/
         cp core/mod/*.mod tests/share/mod/
-        nrnivmodl -coreneuron -incflags '-DENABLE_CORENEURON -I${SONATAREPORT_DIR}/include -I/usr/include/hdf5/mpich -I/usr/lib/x86_64-linux-gnu/mpich' \
-          -loadflags '-L${SONATAREPORT_DIR}/lib -lsonatareport -Wl,-rpath,${SONATAREPORT_DIR}/lib -L/usr/lib/x86_64-linux-gnu/hdf5/mpich -lhdf5 -Wl,-rpath,/usr/lib/x86_64-linux-gnu/hdf5/mpich/ -L/usr/lib/x86_64-linux-gnu/ -lmpich -Wl,-rpath,/usr/lib/x86_64-linux-gnu/' \
-          tests/share/mod
+        ./docker/build_neurodamus.sh tests/share/mod
 
     - name: Example run
       run: |

--- a/docker/build_neurodamus.sh
+++ b/docker/build_neurodamus.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 
 echo "build models from folder " $1
-nrnivmodl -coreneuron -incflags '-DENABLE_CORENEURON -I${SONATAREPORT_DIR}/include -I/usr/include/hdf5/mpich -I/usr/lib/x86_64-linux-gnu/mpich' -loadflags '-L${SONATAREPORT_DIR}/lib -lsonatareport -Wl,-rpath,${SONATAREPORT_DIR}/lib -L/usr/lib/x86_64-linux-gnu/hdf5/mpich -lhdf5 -Wl,-rpath,/usr/lib/x86_64-linux-gnu/hdf5/mpich/ -L/usr/lib/x86_64-linux-gnu/ -lmpich -Wl,-rpath,/usr/lib/x86_64-linux-gnu/' "$1"
+
+NRNIVMODL_INCLUDE_FLAGS="-I${SONATAREPORT_DIR}/include -I/usr/include/hdf5/mpich -I/usr/lib/x86_64-linux-gnu/mpich"
+NRNIVMODL_LOAD_FLAGS="-L${SONATAREPORT_DIR}/lib -lsonatareport -Wl,-rpath,${SONATAREPORT_DIR}/lib -L/usr/lib/x86_64-linux-gnu/hdf5/mpich -lhdf5 -Wl,-rpath,/usr/lib/x86_64-linux-gnu/hdf5/mpich/ -L/usr/lib/x86_64-linux-gnu/ -lmpich -Wl,-rpath,/usr/lib/x86_64-linux-gnu/"
+
+if [[ "$2" == "--only-neuron" ]]; then
+    nrnivmodl -incflags ${NRNIVMODL_INCLUDE_FLAGS} -loadflags ${NRNIVMODL_LOAD_FLAGS} "$1"
+else
+    nrnivmodl -coreneuron -incflags "-DENABLE_CORENEURON ${NRNIVMODL_INCLUDE_FLAGS}" -loadflags "${NRNIVMODL_LOAD_FLAGS}" "$1"
+fi


### PR DESCRIPTION
Add `--only-neuron` CLI argument from the [Spack recipe](https://github.com/BlueBrain/spack/pull/2198/files)

## Context
Add option for building MOD files only with NEURON

## Scope
`build_neurodamus.sh` script that should be the same as the `Spack` recipe of `Neurodamus`

## Testing


## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
