### PR TITLE
[BBPBGLIB-854] Implement a CLI option to run coreneuron in direct mode without writing model data to disk

### DIFF
--- a/neurodamus/commands.py
+++ b/neurodamus/commands.py
@@ -61,7 +61,8 @@ def neurodamus(args=None):
         --model-stats           Show model stats in CoreNEURON simulations [default: False]
         --dry-run               Dry-run simulation to estimate memory usage [default: False]
         --num-target-ranks=<number>  Number of ranks to target for dry-run load balancing
-        --skip-write-model      Run CoreNeuron in direct mode, without writing model data to disk
+        --coreneuron-direct-mode     Run CoreNeuron in direct memory mode transfered from Neuron,
+                                     without writing model data to disk.
     """
     options = docopt_sanitize(docopt(neurodamus.__doc__, args))
     config_file = options.pop("ConfigFile")

--- a/neurodamus/commands.py
+++ b/neurodamus/commands.py
@@ -61,6 +61,7 @@ def neurodamus(args=None):
         --model-stats           Show model stats in CoreNEURON simulations [default: False]
         --dry-run               Dry-run simulation to estimate memory usage [default: False]
         --num-target-ranks=<number>  Number of ranks to target for dry-run load balancing
+        --skip-write-model      Run CoreNeuron in direct mode, without writing model data to disk
     """
     options = docopt_sanitize(docopt(neurodamus.__doc__, args))
     config_file = options.pop("ConfigFile")

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -1233,6 +1233,7 @@ class SynapseRuleManager(ConnectionManagerBase):
     def finalize(self, base_seed=0, sim_corenrn=False, **kwargs):
         """Create the actual synapses and netcons. See super() docstring
         """
+        # CoreNeuron will handle replays automatically with its own PatternStim
         kwargs.setdefault("replay_mode", ReplayMode.AS_REQUIRED)
         super().finalize(base_seed, sim_corenrn, **kwargs)
 

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -1233,7 +1233,6 @@ class SynapseRuleManager(ConnectionManagerBase):
     def finalize(self, base_seed=0, sim_corenrn=False, **kwargs):
         """Create the actual synapses and netcons. See super() docstring
         """
-        # CoreNeuron will handle replays automatically with its own PatternStim
         kwargs.setdefault("replay_mode", ReplayMode.AS_REQUIRED)
         super().finalize(base_seed, sim_corenrn, **kwargs)
 

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -1021,7 +1021,7 @@ def _coreneuron_direct_mode(config: _SimConfig, run_conf):
             logging.warning("--coreneuron-direct-mode not valid for multi-cyle model building, "
                             "continue with file mode")
             direct_mode = False
-        if config.save:
+        if config.save or config.restore:
             logging.warning("--coreneuron-direct-mode not valid for save/restore, "
                             "continue with file mode")
             direct_mode = False

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -1013,18 +1013,13 @@ def _coreneuron_direct_mode(config: _SimConfig, run_conf):
     direct_mode = user_config.coreneuron_direct_mode
     if direct_mode:
         if config.use_neuron:
-            logging.warning("--coreneuron-direct-mode not valid for NEURON, will do nothing")
-            direct_mode = False
+            raise ConfigurationError("--coreneuron-direct-mode is not valid for NEURON")
         if config.modelbuilding_steps > 1:
             logging.warning("--coreneuron-direct-mode not valid for multi-cyle model building, "
                             "continue with file mode")
             direct_mode = False
         if config.save or config.restore:
             logging.warning("--coreneuron-direct-mode not valid for save/restore, "
-                            "continue with file mode")
-            direct_mode = False
-        if run_conf.get("LFPWeightsPath"):
-            logging.warning("--coreneuron-direct-mode not valid for LFP, "
                             "continue with file mode")
             direct_mode = False
 

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -273,7 +273,6 @@ class _SimConfig(object):
         cls.cli_options = CliOptions(**(cli_options or {}))
         cls.dry_run = cls.cli_options.dry_run
         cls.num_target_ranks = cls.cli_options.num_target_ranks
-        cls.coreneuron_direct_mode = cls.cli_options.coreneuron_direct_mode
         # change simulator by request before validator and init hoc config
         if cls.cli_options.simulator:
             cls._parsed_run["Simulator"] = cls.cli_options.simulator
@@ -1010,12 +1009,24 @@ def _spikes_sort_order(config: _SimConfig, run_conf):
 
 @SimConfig.validator
 def _coreneuron_direct_mode(config: _SimConfig, run_conf):
-    if config.coreneuron_direct_mode:
+    user_config = config.cli_options
+    direct_mode = user_config.coreneuron_direct_mode
+    if direct_mode:
         if config.use_coreneuron:
-            logging.info("Run CORENEURON without writing model data to disk")
+            logging.info("Run CORENEURON direct mode without writing model data to disk")
         else:
             logging.warning("--coreneuron-direct-mode not valid for NEURON, continue with NEURON")
-            config.coreneuron_direct_mode = False
+            direct_mode = False
+        if config.modelbuilding_steps > 1:
+            logging.warning("--coreneuron-direct-mode not valid for multi-cyle model building, "
+                            "continue with file mode")
+            direct_mode = False
+        if config.save:
+            logging.warning("--coreneuron-direct-mode not valid for save/restore, "
+                            "continue with file mode")
+            direct_mode = False
+
+    config.coreneuron_direct_mode = direct_mode
 
 
 def get_debug_cell_gid(cli_options):

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -75,11 +75,8 @@ class CliOptions(ConfigT):
     model_stats = False
     simulator = None
     dry_run = False
-<<<<<<< HEAD
     num_target_ranks = None
-=======
-    skip_write_model = False
->>>>>>> a8a10a6... Cli option
+    coreneuron_direct_mode = False
 
     # Restricted Functionality support, mostly for testing
 
@@ -238,11 +235,8 @@ class _SimConfig(object):
     spike_location = "soma"
     spike_threshold = -30
     dry_run = False
-<<<<<<< HEAD
     num_target_ranks = None
-=======
-    skip_write_model = False
->>>>>>> a8a10a6... Cli option
+    coreneuron_direct_mode = False
 
     _validators = []
     _requisitors = []
@@ -278,11 +272,8 @@ class _SimConfig(object):
         cls.modifications = compat.Map(cls._config_parser.parsedModifications or {})
         cls.cli_options = CliOptions(**(cli_options or {}))
         cls.dry_run = cls.cli_options.dry_run
-<<<<<<< HEAD
         cls.num_target_ranks = cls.cli_options.num_target_ranks
-=======
-        cls.skip_write_model = cls.cli_options.skip_write_model
->>>>>>> a8a10a6... Cli option
+        cls.coreneuron_direct_mode = cls.cli_options.coreneuron_direct_mode
         # change simulator by request before validator and init hoc config
         if cls.cli_options.simulator:
             cls._parsed_run["Simulator"] = cls.cli_options.simulator
@@ -1018,15 +1009,13 @@ def _spikes_sort_order(config: _SimConfig, run_conf):
 
 
 @SimConfig.validator
-def _skip_write_coreneuron_model(config: _SimConfig, run_conf):
-    if config.skip_write_model:
+def _coreneuron_direct_mode(config: _SimConfig, run_conf):
+    if config.coreneuron_direct_mode:
         if config.use_coreneuron:
             logging.info("Run CORENEURON without writing model data to disk")
-            # config.use_neuron = True
-            # config.use_coreneuron = False
         else:
-            logging.warning("--skip-write-model not valid for NEURON, continue as usual")
-            config.skip_write_model = False
+            logging.warning("--coreneuron-direct-mode not valid for NEURON, continue with NEURON")
+            config.coreneuron_direct_mode = False
 
 
 def get_debug_cell_gid(cli_options):

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -1012,10 +1012,8 @@ def _coreneuron_direct_mode(config: _SimConfig, run_conf):
     user_config = config.cli_options
     direct_mode = user_config.coreneuron_direct_mode
     if direct_mode:
-        if config.use_coreneuron:
-            logging.info("Run CORENEURON direct mode without writing model data to disk")
-        else:
-            logging.warning("--coreneuron-direct-mode not valid for NEURON, continue with NEURON")
+        if config.use_neuron:
+            logging.warning("--coreneuron-direct-mode not valid for NEURON, will do nothing")
             direct_mode = False
         if config.modelbuilding_steps > 1:
             logging.warning("--coreneuron-direct-mode not valid for multi-cyle model building, "
@@ -1025,7 +1023,13 @@ def _coreneuron_direct_mode(config: _SimConfig, run_conf):
             logging.warning("--coreneuron-direct-mode not valid for save/restore, "
                             "continue with file mode")
             direct_mode = False
+        if run_conf.get("LFPWeightsPath"):
+            logging.warning("--coreneuron-direct-mode not valid for LFP, "
+                            "continue with file mode")
+            direct_mode = False
 
+    if direct_mode:
+        logging.info("Run CORENEURON direct mode without writing model data to disk")
     config.coreneuron_direct_mode = direct_mode
 
 

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -75,7 +75,11 @@ class CliOptions(ConfigT):
     model_stats = False
     simulator = None
     dry_run = False
+<<<<<<< HEAD
     num_target_ranks = None
+=======
+    skip_write_model = False
+>>>>>>> a8a10a6... Cli option
 
     # Restricted Functionality support, mostly for testing
 
@@ -234,7 +238,11 @@ class _SimConfig(object):
     spike_location = "soma"
     spike_threshold = -30
     dry_run = False
+<<<<<<< HEAD
     num_target_ranks = None
+=======
+    skip_write_model = False
+>>>>>>> a8a10a6... Cli option
 
     _validators = []
     _requisitors = []
@@ -270,7 +278,11 @@ class _SimConfig(object):
         cls.modifications = compat.Map(cls._config_parser.parsedModifications or {})
         cls.cli_options = CliOptions(**(cli_options or {}))
         cls.dry_run = cls.cli_options.dry_run
+<<<<<<< HEAD
         cls.num_target_ranks = cls.cli_options.num_target_ranks
+=======
+        cls.skip_write_model = cls.cli_options.skip_write_model
+>>>>>>> a8a10a6... Cli option
         # change simulator by request before validator and init hoc config
         if cls.cli_options.simulator:
             cls._parsed_run["Simulator"] = cls.cli_options.simulator
@@ -1003,6 +1015,18 @@ def _spikes_sort_order(config: _SimConfig, run_conf):
     if order not in ["none", "by_time"]:
         raise ConfigurationError("Unsupported spikes sort order %s, " % order +
                                  "BBP supports 'none' and 'by_time'")
+
+
+@SimConfig.validator
+def _skip_write_coreneuron_model(config: _SimConfig, run_conf):
+    if config.skip_write_model:
+        if config.use_coreneuron:
+            logging.info("Run CORENEURON without writing model data to disk")
+            # config.use_neuron = True
+            # config.use_coreneuron = False
+        else:
+            logging.warning("--skip-write-model not valid for NEURON, continue as usual")
+            config.skip_write_model = False
 
 
 def get_debug_cell_gid(cli_options):

--- a/neurodamus/core/coreneuron_configuration.py
+++ b/neurodamus/core/coreneuron_configuration.py
@@ -96,7 +96,7 @@ class _CoreNEURONConfig(object):
         report_conf = Path(self.output_root) / self.report_config_file
         report_conf.parent.mkdir(parents=True, exist_ok=True)
         with report_conf.open("ab") as fp:
-            # Write the formatted strfing to the file
+            # Write the formatted string to the file
             fp.write(("%s %s %s %s %s %s %d %lf %lf %lf %d %d\n" % (
                 report_name,
                 target_name,
@@ -175,7 +175,7 @@ class _CoreNEURONConfig(object):
         from neuron import coreneuron
         from . import NeurodamusCore as Nd
 
-        # Nd.cvode.cache_efficient(1)
+        Nd.cvode.cache_efficient(1)
         coreneuron.enable = True
         if not direct:
             coreneuron.file_mode = True
@@ -190,7 +190,6 @@ class _CoreNEURONConfig(object):
         else:
             logging.info(f"++WJI coreneuron.file_mode {coreneuron.file_mode}")
             coreneuron.sim_config = f"{self.output_root}/{self.sim_config_file}"
-        # Nd.stdinit()
         Nd.pc.psolve(Nd.tstop)
 
 

--- a/neurodamus/core/coreneuron_configuration.py
+++ b/neurodamus/core/coreneuron_configuration.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from ._utils import run_only_rank0
 from . import NeurodamusCore as Nd
 from ..report import get_section_index
+from ..utils.logging import log_verbose
 
 
 class CompartmentMapping:
@@ -171,13 +172,13 @@ class _CoreNEURONConfig(object):
             fp.write(filename)
             fp.write("\n")
 
-    def psolve_core(self, save_path=None, restore_path=None, direct=True):
+    def psolve_core(self, save_path=None, restore_path=None, skip_write_model=False):
         from neuron import coreneuron
         from . import NeurodamusCore as Nd
 
         Nd.cvode.cache_efficient(1)
         coreneuron.enable = True
-        if not direct:
+        if not skip_write_model:
             coreneuron.file_mode = True
             coreneuron.sim_config = f"{self.output_root}/{self.sim_config_file}"
             if save_path:
@@ -188,7 +189,7 @@ class _CoreNEURONConfig(object):
             coreneuron.skip_write_model_to_disk = True
             coreneuron.model_path = f"{self.datadir}"
         else:
-            logging.info(f"++WJI coreneuron.file_mode {coreneuron.file_mode}")
+            log_verbose("Run CORENEURON direct mode")
             coreneuron.sim_config = f"{self.output_root}/{self.sim_config_file}"
         Nd.pc.psolve(Nd.tstop)
 

--- a/neurodamus/core/coreneuron_configuration.py
+++ b/neurodamus/core/coreneuron_configuration.py
@@ -172,25 +172,21 @@ class _CoreNEURONConfig(object):
             fp.write(filename)
             fp.write("\n")
 
-    def psolve_core(self, save_path=None, restore_path=None, skip_write_model=False):
+    def psolve_core(self, save_path=None, restore_path=None, coreneuron_direct_mode=False):
         from neuron import coreneuron
         from . import NeurodamusCore as Nd
 
         Nd.cvode.cache_efficient(1)
         coreneuron.enable = True
-        if not skip_write_model:
-            coreneuron.file_mode = True
-            coreneuron.sim_config = f"{self.output_root}/{self.sim_config_file}"
-            if save_path:
-                coreneuron.save_path = save_path
-            if restore_path:
-                coreneuron.restore_path = restore_path
-            # Model is already written to disk by calling pc.nrncore_write()
-            coreneuron.skip_write_model_to_disk = True
-            coreneuron.model_path = f"{self.datadir}"
-        else:
-            log_verbose("Run CORENEURON direct mode")
-            coreneuron.sim_config = f"{self.output_root}/{self.sim_config_file}"
+        coreneuron.file_mode = not coreneuron_direct_mode
+        coreneuron.sim_config = f"{self.output_root}/{self.sim_config_file}"
+        if save_path:
+            coreneuron.save_path = save_path
+        if restore_path:
+            coreneuron.restore_path = restore_path
+        # Model is already written to disk by calling pc.nrncore_write()
+        coreneuron.skip_write_model_to_disk = True
+        coreneuron.model_path = f"{self.datadir}"
         Nd.pc.psolve(Nd.tstop)
 
 

--- a/neurodamus/core/coreneuron_configuration.py
+++ b/neurodamus/core/coreneuron_configuration.py
@@ -96,7 +96,7 @@ class _CoreNEURONConfig(object):
         report_conf = Path(self.output_root) / self.report_config_file
         report_conf.parent.mkdir(parents=True, exist_ok=True)
         with report_conf.open("ab") as fp:
-            # Write the formatted string to the file
+            # Write the formatted strfing to the file
             fp.write(("%s %s %s %s %s %s %d %lf %lf %lf %d %d\n" % (
                 report_name,
                 target_name,
@@ -171,21 +171,26 @@ class _CoreNEURONConfig(object):
             fp.write(filename)
             fp.write("\n")
 
-    def psolve_core(self, save_path=None, restore_path=None):
+    def psolve_core(self, save_path=None, restore_path=None, direct=True):
         from neuron import coreneuron
         from . import NeurodamusCore as Nd
 
-        Nd.cvode.cache_efficient(1)
+        # Nd.cvode.cache_efficient(1)
         coreneuron.enable = True
-        coreneuron.file_mode = True
-        coreneuron.sim_config = f"{self.output_root}/{self.sim_config_file}"
-        if save_path:
-            coreneuron.save_path = save_path
-        if restore_path:
-            coreneuron.restore_path = restore_path
-        # Model is already written to disk by calling pc.nrncore_write()
-        coreneuron.skip_write_model_to_disk = True
-        coreneuron.model_path = f"{self.datadir}"
+        if not direct:
+            coreneuron.file_mode = True
+            coreneuron.sim_config = f"{self.output_root}/{self.sim_config_file}"
+            if save_path:
+                coreneuron.save_path = save_path
+            if restore_path:
+                coreneuron.restore_path = restore_path
+            # Model is already written to disk by calling pc.nrncore_write()
+            coreneuron.skip_write_model_to_disk = True
+            coreneuron.model_path = f"{self.datadir}"
+        else:
+            logging.info(f"++WJI coreneuron.file_mode {coreneuron.file_mode}")
+            coreneuron.sim_config = f"{self.output_root}/{self.sim_config_file}"
+        # Nd.stdinit()
         Nd.pc.psolve(Nd.tstop)
 
 

--- a/neurodamus/core/coreneuron_configuration.py
+++ b/neurodamus/core/coreneuron_configuration.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from ._utils import run_only_rank0
 from . import NeurodamusCore as Nd
 from ..report import get_section_index
-from ..utils.logging import log_verbose
 
 
 class CompartmentMapping:

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1130,6 +1130,9 @@ class Node:
         # This is incompatible with efficient caching atm AND Incompatible with mcd & Glut
         if not self._is_ngv_run:
             Nd.cvode.cache_efficient("ElectrodesPath" not in self._run_conf)
+        else:
+            Nd.cvode.cache_efficient(1)
+
         self._pc.set_maxstep(4)
         with timeit(name="stdinit"):
             Nd.stdinit()
@@ -1312,7 +1315,7 @@ class Node:
             self.sonata_spikes()
         if SimConfig.use_coreneuron:
             print_mem_usage()
-            self.clear_model(avoid_clearing_queues=False)
+            # self.clear_model(avoid_clearing_queues=False)
             self._run_coreneuron()
         return timings
 
@@ -1443,8 +1446,8 @@ class Node:
         pool_shrink()
 
         # Free event queues in NEURON
-        if not avoid_clearing_queues:
-            free_event_queues()
+        # if not avoid_clearing_queues:
+        #     free_event_queues()
 
         # Garbage collect all Python objects without references
         gc.collect()

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -283,7 +283,7 @@ class Node:
             self._run_conf = SimConfig.run_conf
             self._target_manager = TargetManager(self._run_conf)
             self._target_spec = TargetSpec(self._run_conf.get("CircuitTarget"))
-            if SimConfig.use_neuron or SimConfig.skip_write_model:
+            if SimConfig.use_neuron or SimConfig.coreneuron_direct_mode:
                 self._sonatareport_helper = Nd.SonataReportHelper(Nd.dt, True)
             self._base_circuit: CircuitConfig = SimConfig.base_circuit
             self._extra_circuits = SimConfig.extra_circuits
@@ -1094,7 +1094,7 @@ class Node:
         if corenrn_gen:
             self._sim_corenrn_write_config()
 
-        if SimConfig.use_neuron or SimConfig.skip_write_model:
+        if SimConfig.use_neuron or SimConfig.coreneuron_direct_mode:
             self._sim_init_neuron()
 
         if ospath.isfile("debug_gids.txt"):
@@ -1278,11 +1278,11 @@ class Node:
 
         if not corenrn_restore:
             CompartmentMapping(self._circuits.global_manager).register_mapping()
-            if not SimConfig.skip_write_model:
+            if not SimConfig.coreneuron_direct_mode:
                 with self._coreneuron_ensure_all_ranks_have_gids(CoreConfig.datadir):
                     self._pc.nrnbbcore_write(CoreConfig.datadir)
                     MPI.barrier()  # wait for all ranks to finish corenrn data generation
-            
+
         CoreConfig.write_sim_config(
             Nd.tstop,
             Nd.dt,
@@ -1313,10 +1313,10 @@ class Node:
             self.sonata_spikes()
         if SimConfig.use_coreneuron:
             print_mem_usage()
-            if not SimConfig.skip_write_model:
+            if not SimConfig.coreneuron_direct_mode:
                 self.clear_model(avoid_clearing_queues=False)
             self._run_coreneuron()
-            if SimConfig.skip_write_model:
+            if SimConfig.coreneuron_direct_mode:
                 self.sonata_spikes()
         return timings
 
@@ -1334,7 +1334,7 @@ class Node:
         CoreConfig.psolve_core(
             getattr(SimConfig, "save", None),
             getattr(SimConfig, "restore", None),
-            SimConfig.skip_write_model
+            SimConfig.coreneuron_direct_mode
         )
 
     #

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -283,8 +283,7 @@ class Node:
             self._run_conf = SimConfig.run_conf
             self._target_manager = TargetManager(self._run_conf)
             self._target_spec = TargetSpec(self._run_conf.get("CircuitTarget"))
-            if SimConfig.use_neuron:
-                self._sonatareport_helper = Nd.SonataReportHelper(Nd.dt, True)
+            self._sonatareport_helper = Nd.SonataReportHelper(Nd.dt, True)
             self._base_circuit: CircuitConfig = SimConfig.base_circuit
             self._extra_circuits = SimConfig.extra_circuits
             self._pr_cell_gid = get_debug_cell_gid(options)
@@ -1094,8 +1093,8 @@ class Node:
         if corenrn_gen:
             self._sim_corenrn_write_config()
 
-        if SimConfig.use_neuron:
-            self._sim_init_neuron()
+        # if SimConfig.use_neuron:
+        self._sim_init_neuron()
 
         if ospath.isfile("debug_gids.txt"):
             self.dump_circuit_config()
@@ -1312,8 +1311,11 @@ class Node:
             self.sonata_spikes()
         if SimConfig.use_coreneuron:
             print_mem_usage()
-            # self.clear_model(avoid_clearing_queues=False)
+            if not SimConfig.skip_write_model:
+                self.clear_model(avoid_clearing_queues=False)
             self._run_coreneuron()
+            if SimConfig.skip_write_model:
+                self.sonata_spikes()
         return timings
 
     # -
@@ -1373,6 +1375,9 @@ class Node:
     @mpi_no_errors
     @timeit(name="psolve")
     def solve(self, tstop=None):
+        from neuron import coreneuron
+        Nd.cvode.cache_efficient(1)
+        coreneuron.enable=True
         """Call solver with a given stop time (default: whole interval).
         Be sure to have sim_init()'d the simulation beforehand
         """

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -858,9 +858,9 @@ class Node:
             has_gids = len(self._circuits.global_manager.get_final_gids()) > 0
             report = Report(*rep_params, SimConfig.use_coreneuron) if has_gids else None
 
-            # In coreneuron direct (in-memory) mode, i_membrane data is copied
-            # between neuron and coreneuron
-            if SimConfig.coreneuron_direct_mode and "i_membrane" in rep_params.report_on:
+            # With coreneuron direct mode, enable fast membrane current calculation for i_membrane
+            if SimConfig.coreneuron_direct_mode and \
+                    "i_membrane" in rep_params.report_on or rep_params.rep_type == "lfp":
                 Nd.cvode.use_fast_imem(1)
 
             if not SimConfig.use_coreneuron or rep_params.rep_type == "Synapse":

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1130,9 +1130,6 @@ class Node:
         # This is incompatible with efficient caching atm AND Incompatible with mcd & Glut
         if not self._is_ngv_run:
             Nd.cvode.cache_efficient("ElectrodesPath" not in self._run_conf)
-        else:
-            Nd.cvode.cache_efficient(1)
-
         self._pc.set_maxstep(4)
         with timeit(name="stdinit"):
             Nd.stdinit()
@@ -1446,8 +1443,8 @@ class Node:
         pool_shrink()
 
         # Free event queues in NEURON
-        # if not avoid_clearing_queues:
-        #     free_event_queues()
+        if not avoid_clearing_queues:
+            free_event_queues()
 
         # Garbage collect all Python objects without references
         gc.collect()

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1212,9 +1212,11 @@ class Node:
                 dummyfile.write("%s\n0\n" % coredata_version)
 
     # -
-    def _sim_corenrn_configure_datadir(self, corenrn_restore):
+    def _sim_corenrn_configure_datadir(self, corenrn_restore, coreneuron_direct_mode):
         corenrn_datadir = SimConfig.coreneuron_datadir
         os.makedirs(corenrn_datadir, exist_ok=True)
+        if coreneuron_direct_mode:
+            return corenrn_datadir
         corenrn_datadir_shm = SHMUtil.get_datadir_shm(corenrn_datadir)
 
         # Clean-up any previous simulations in the same output directory
@@ -1273,7 +1275,8 @@ class Node:
     @timeit(name="corewrite")
     def _sim_corenrn_write_config(self, corenrn_restore=False):
         log_stage("Dataset generation for CoreNEURON")
-        CoreConfig.datadir = self._sim_corenrn_configure_datadir(corenrn_restore)
+        CoreConfig.datadir = self._sim_corenrn_configure_datadir(corenrn_restore,
+                                                                 SimConfig.coreneuron_direct_mode)
         fwd_skip = self._run_conf.get("ForwardSkip", 0) if not corenrn_restore else 0
 
         if not corenrn_restore:

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -283,7 +283,8 @@ class Node:
             self._run_conf = SimConfig.run_conf
             self._target_manager = TargetManager(self._run_conf)
             self._target_spec = TargetSpec(self._run_conf.get("CircuitTarget"))
-            self._sonatareport_helper = Nd.SonataReportHelper(Nd.dt, True)
+            if SimConfig.use_neuron or SimConfig.skip_write_model:
+                self._sonatareport_helper = Nd.SonataReportHelper(Nd.dt, True)
             self._base_circuit: CircuitConfig = SimConfig.base_circuit
             self._extra_circuits = SimConfig.extra_circuits
             self._pr_cell_gid = get_debug_cell_gid(options)
@@ -1093,8 +1094,8 @@ class Node:
         if corenrn_gen:
             self._sim_corenrn_write_config()
 
-        # if SimConfig.use_neuron:
-        self._sim_init_neuron()
+        if SimConfig.use_neuron or SimConfig.skip_write_model:
+            self._sim_init_neuron()
 
         if ospath.isfile("debug_gids.txt"):
             self.dump_circuit_config()
@@ -1277,10 +1278,11 @@ class Node:
 
         if not corenrn_restore:
             CompartmentMapping(self._circuits.global_manager).register_mapping()
-            with self._coreneuron_ensure_all_ranks_have_gids(CoreConfig.datadir):
-                self._pc.nrnbbcore_write(CoreConfig.datadir)
-                MPI.barrier()  # wait for all ranks to finish corenrn data generation
-
+            if not SimConfig.skip_write_model:
+                with self._coreneuron_ensure_all_ranks_have_gids(CoreConfig.datadir):
+                    self._pc.nrnbbcore_write(CoreConfig.datadir)
+                    MPI.barrier()  # wait for all ranks to finish corenrn data generation
+            
         CoreConfig.write_sim_config(
             Nd.tstop,
             Nd.dt,
@@ -1331,7 +1333,8 @@ class Node:
         logging.info("Launching simulation with CoreNEURON")
         CoreConfig.psolve_core(
             getattr(SimConfig, "save", None),
-            getattr(SimConfig, "restore", None)
+            getattr(SimConfig, "restore", None),
+            SimConfig.skip_write_model
         )
 
     #
@@ -1375,9 +1378,6 @@ class Node:
     @mpi_no_errors
     @timeit(name="psolve")
     def solve(self, tstop=None):
-        from neuron import coreneuron
-        Nd.cvode.cache_efficient(1)
-        coreneuron.enable=True
         """Call solver with a given stop time (default: whole interval).
         Be sure to have sim_init()'d the simulation beforehand
         """

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -858,6 +858,11 @@ class Node:
             has_gids = len(self._circuits.global_manager.get_final_gids()) > 0
             report = Report(*rep_params, SimConfig.use_coreneuron) if has_gids else None
 
+            # In coreneuron direct (in-memory) mode, i_membrane data is copied
+            # between neuron and coreneuron
+            if SimConfig.coreneuron_direct_mode and "i_membrane" in rep_params.report_on:
+                Nd.cvode.use_fast_imem(1)
+
             if not SimConfig.use_coreneuron or rep_params.rep_type == "Synapse":
                 try:
                     self._report_setup(report, rep_conf, target, rep_params.rep_type)

--- a/tests/integration-e2e/test_coreneuron_directmode.py
+++ b/tests/integration-e2e/test_coreneuron_directmode.py
@@ -1,0 +1,37 @@
+import os
+import numpy.testing as npt
+import numpy as np
+
+
+def test_coreneuron_no_write_model(USECASE3):
+    from libsonata import SpikeReader, ElementReportReader
+    from neurodamus import Neurodamus
+    from neurodamus.core.configuration import SimConfig
+    nd = Neurodamus(
+        str(USECASE3 / "simulation_sonata_coreneuron.json"),
+        keep_build=True,
+        skip_write_model=True
+    )
+    nd.run()
+    coreneuron_data = SimConfig.coreneuron_datadir
+    assert not next(os.scandir(coreneuron_data), None), f"{coreneuron_data} should be empty."
+
+    spikes_path = os.path.join(SimConfig.output_root, nd._run_conf.get("SpikesFile"))
+    spikes_reader = SpikeReader(spikes_path)
+    pop_A = spikes_reader["NodeA"]
+    pop_B = spikes_reader["NodeB"]
+    spike_dict = pop_A.get_dict()
+    npt.assert_allclose(spike_dict["timestamps"][:10], np.array([0.2, 0.3, 0.3, 2.5, 3.4,
+                                                                4.2, 5.5, 7., 7.4, 8.6]))
+    npt.assert_allclose(spike_dict["node_ids"][:10], np.array([0, 1, 2, 0, 1, 2, 0, 0, 1, 2]))
+    assert not pop_B.get()
+
+    soma_reader = ElementReportReader(SimConfig.reports.get("soma_report").get('FileName'))
+    soma_A = soma_reader["NodeA"]
+    soma_B = soma_reader["NodeB"]
+    data_A = soma_A.get(tstop=0.5)
+    data_B = soma_B.get(tstop=0.5)
+    npt.assert_allclose(data_A.data, np.array([[-75.], [-39.78627], [-14.380434], [15.3370695],
+                                               [1.7240616], [-13.333434]]))
+    npt.assert_allclose(data_B.data, np.array([[-75.], [-75.00682], [-75.010414], [-75.0118],
+                                               [-75.01173], [-75.010635]]))

--- a/tests/integration-e2e/test_coreneuron_directmode.py
+++ b/tests/integration-e2e/test_coreneuron_directmode.py
@@ -10,7 +10,7 @@ def test_coreneuron_no_write_model(USECASE3):
     nd = Neurodamus(
         str(USECASE3 / "simulation_sonata_coreneuron.json"),
         keep_build=True,
-        skip_write_model=True
+        coreneuron_direct_mode=True
     )
     nd.run()
     coreneuron_data = SimConfig.coreneuron_datadir


### PR DESCRIPTION
## Context
This PR implements a new CLI option "--coreneuron-direct-mode" that enables to run the coreneuron simulation using direct memory transferred from neuron, without writing intermediate model data to disk.

## Scope

- When "--coreneuron-direct-mode", we set the Coreneuron parameter`coreneuron.file_mode=False`. 
- And Coreneuron writes the element reports but not the spike report.  So we still create `sim.conf`, `report.conf` and an empty folder `coreneuron_input`. The spike report is created explicitly in neurodamus via `sonata_spikes()` just like the Neuron runs.
- Enable fast membrane current calculation `Nd.cvode.use_fast_imem(1)` for  `i_membrane` and `lfp` reports.

## Testing
New test file `test_coreneuron_directmode.py`.
The blueconfig pipeline tests with  "--coreneuron-direct-mode" enabled have been done manually in https://bbpgitlab.epfl.ch/hpc/sim/blueconfigs/-/pipelines/219862 using the blueconfig [branch](https://bbpgitlab.epfl.ch/hpc/sim/blueconfigs/-/merge_requests/114).


## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
