### PR TITLE
Fix memory usage reporting on MacOS

### DIFF
--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -10,7 +10,6 @@ import os
 import json
 import psutil
 import multiprocessing
-from resource import getrusage, RUSAGE_SELF
 
 from ..core import MPI, NeurodamusCore as Nd, run_only_rank0
 

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -10,6 +10,7 @@ import os
 import json
 import psutil
 import multiprocessing
+from resource import getrusage, RUSAGE_SELF
 
 from ..core import MPI, NeurodamusCore as Nd, run_only_rank0
 
@@ -140,9 +141,7 @@ def get_mem_usage_kb():
     """
     Return memory usage information across all ranks, in KiloBytes
     """
-    with open("/proc/self/statm") as fd:
-        _, data_size, _ = fd.read().split(maxsplit=2)
-    usage_kb = float(data_size) * os.sysconf("SC_PAGE_SIZE") / 1024
+    usage_kb = psutil.Process(os.getpid()).memory_info().rss / 1024
 
     return usage_kb
 


### PR DESCRIPTION
## Context
<!-- Please brifly describe the problem the PR solves and what the solution was -->
MacOS does not use `/proc/`, and consequently Neurodamus crashes when attempting to determine the memory usage of the current process. The fix is to instead use the built-in [`resource`](https://docs.python.org/3/library/resource.html#resource-usage) module to get the memory usage, which works on both Linux and MacOS.

## Scope
<!--
Please describe in more detail the several changes implemented. How did we solve it?
E.g. change component-A to..., created a new data structure, etc...
-->


## Testing
<!--
Please add a new test under `tests`. Consider the following cases:

 1. If the change is in an independent component (e.g, a new container type, a parser, etc) a bare unit test should be sufficient. See e.g. `tests/test_coords.py`
 2. If you are fixing or adding components supporting a scientific use case, affecting node or synapse creation, etc..., which typically rely on Neuron, tests should set up a simulation using that feature, instantiate neurodamus, **assess the state**, run the simulation and check the results are as expected.
    See an example at `tests/test_simulation.py#L66`
-->

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
