### PR TITLE
Fix call to `trim_memory` on non-GNU C libraries

### DIFF
--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -40,7 +40,7 @@ def trim_memory():
             memory_trimmed = libc.malloc_trim(0)
             if memory_trimmed:
                 logging.info("malloc_trim: memory released back to the system.")
-        except OSError:
+        except (OSError, AttributeError):
             logging.error("Unable to call malloc_trim.")
             logging.info("malloc_trim: not possible to release any memory.")
 


### PR DESCRIPTION
## Context
<!-- Please brifly describe the problem the PR solves and what the solution was -->
The function `malloc_trim` is specific to the GNU C library (glibc), so the call to it in `trim_memory` raises an `AttributeError` when running with other C library implementations (like the default one shipped with MacOS), which we now catch in the `except` block.

## Scope
<!--
Please describe in more detail the several changes implemented. How did we solve it?
E.g. change component-A to..., created a new data structure, etc...
-->

## Testing
<!--
Please add a new test under `tests`. Consider the following cases:

 1. If the change is in an independent component (e.g, a new container type, a parser, etc) a bare unit test should be sufficient. See e.g. `tests/test_coords.py`
 2. If you are fixing or adding components supporting a scientific use case, affecting node or synapse creation, etc..., which typically rely on Neuron, tests should set up a simulation using that feature, instantiate neurodamus, **assess the state**, run the simulation and check the results are as expected.
    See an example at `tests/test_simulation.py#L66`
-->

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
