### PR TITLE
CoreConfig: write_report_count() should always create a new report.conf

### DIFF
--- a/neurodamus/core/coreneuron_configuration.py
+++ b/neurodamus/core/coreneuron_configuration.py
@@ -80,15 +80,15 @@ class _CoreNEURONConfig(object):
             fp.write("mpi=true\n")
 
     @run_only_rank0
-    def write_report_count(self, count):
+    def write_report_count(self, count, mode="w"):
         report_config = Path(self.output_root) / self.report_config_file
         report_config.parent.mkdir(parents=True, exist_ok=True)
-        with report_config.open("a") as fp:
+        with report_config.open(mode) as fp:
             fp.write(f"{count}\n")
 
     @run_only_rank0
     def write_population_count(self, count):
-        self.write_report_count(count)
+        self.write_report_count(count, mode="a")
 
     @run_only_rank0
     def write_spike_population(self, population_name, population_offset=None):


### PR DESCRIPTION
## Context
The functions that create report.conf were always appending to the file, which resulted in wrong report.conf in some cases when running multiple CoreNEURON simulations.
Fix that by always create a new file when writing the number of reports at the beginning of the report.conf file.

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
