### PR TITLE
[BBPBGLIB-1102] Add load balance based on dry run estimate

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -413,7 +413,7 @@ and fast. The algorithm is as follows:
 
 The user can specify the number of ranks to target using the `--num-target-ranks` flag in the CLI of neurodamus.
 The default value is 40. The allocation dictionary, containing the assignment of gids to ranks per each population,
-is then saved to the `allocation.bin` file in a pickled format. In the near future users will be able to
+is then saved to the `allocation.gz` file in a pickled gzipped format. In the near future users will be able to
 import this data in any following simulation in order to improve the memory balance.
 
 Development

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -413,7 +413,7 @@ and fast. The algorithm is as follows:
 
 The user can specify the number of ranks to target using the `--num-target-ranks` flag in the CLI of neurodamus.
 The default value is 40. The allocation dictionary, containing the assignment of gids to ranks per each population,
-is then saved to the `allocation.gz` file in a pickled gzipped format. In the near future users will be able to
+is then saved to the `allocation.pkl.gz` file in a pickled gzipped format. In the near future users will be able to
 import this data in any following simulation in order to improve the memory balance.
 
 Development

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -391,6 +391,31 @@ part in the execution, is then multiplied by the number of ranks used in the exe
 The final result is then printed to the user in a human readable format together with an estimate
 of the number of nodes needed to run the simulation on the same machine used to run the dry run.
 
+Dry Run Memory Load Balancing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The dry run mode also provides a memory load balancing feature. It helps balance the memory usage
+of the ranks of the simulation, so that the user does not incur easily in out-of-memory errors.
+At the moment the implementation is still WIP so the user can save the allocation data to a file
+but cannot import to use it in a real simulation.
+
+The workflow of the memory load balancing is as follows: for each cell in the circuit we have an
+estimate of both the memory load of the cell itself based on their METype and the amount of synapses
+that each METype has on average. With this information we can have a good estimate of the memory
+load of each gid in the circuit.
+
+We've opted for a greedy approach to distribute the gids in order to keep the implementation simple
+and fast. The algorithm is as follows:
+
+- Sort our ranks in a heap so that the emptiest rank is always at the top
+- Assign gids in batches of 10 to the emptiest rank
+- Rince and repeat until all gids are assigned
+
+The user can specify the number of ranks to target using the `--num-target-ranks` flag in the CLI of neurodamus.
+The default value is 40. The allocation dictionary, containing the assignment of gids to ranks per each population,
+is then saved to the `allocation.bin` file in a pickled format. In the near future users will be able to
+import this data in any following simulation in order to improve the memory balance.
+
 Development
 ------------
 

--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -7,7 +7,6 @@ import hashlib
 import logging  # active only in rank 0 (init)
 import os
 import weakref
-import heapq
 from contextlib import contextmanager
 from io import StringIO
 from os import path as ospath
@@ -527,28 +526,6 @@ class CellDistributor(CellManagerBase):
         log_verbose("Nodes Format: SONATA , Loader: %s", loader.__name__)
         return super().load_nodes(load_balancer, _loader=loader, loader_opts=loader_opts)
 
-    def distribute_cells(self, metype_gids, memory_per_type, num_ranks):
-
-        # Prepare a list of tuples (cell_id, memory_load)
-        cells = [(gid, memory_per_type[cell_type]) for cell_type, gids in metype_gids.items() for gid in gids]
-        # Sort by memory load
-        cells.sort(key=lambda x: x[1], reverse=True)
-
-        ranks = [(0, i) for i in range(num_ranks)]  # (total_memory, rank_id)
-        heapq.heapify(ranks)
-        rank_allocation = {i: [] for i in range(num_ranks)}
-        rank_memory = {i: 0 for i in range(num_ranks)}
-
-        for cell_id, memory in cells:
-            total_memory, rank_id = heapq.heappop(ranks)
-            rank_allocation[rank_id].append(cell_id)
-            total_memory += memory
-            rank_memory[rank_id] = total_memory
-            # Update total memory and re-add to the heap
-            heapq.heappush(ranks, (total_memory, rank_id))
-
-        return rank_allocation, rank_memory
-
     def _instantiate_cells(self, dry_run_stats_obj: DryRunStats = None, **opts):
         """
         Instantiates cells, honouring dry_run if provided
@@ -573,10 +550,6 @@ class CellDistributor(CellManagerBase):
             memory_dict = self._instantiate_cells_dry(CellType, cur_metypes_mem, **opts)
             log_verbose("Updating global dry-run memory counters with %d items", len(memory_dict))
             cur_metypes_mem.update(memory_dict)
-            allocation, total_memory_per_rank = self.distribute_cells(dry_run_stats_obj.metype_gids, dry_run_stats_obj.metype_memory, 40)
-            print("Allocation: ", allocation)
-            print("Total memory per rank: ", total_memory_per_rank)
-            import pdb; pdb.set_trace()
 
 
 class LoadBalance:

--- a/neurodamus/commands.py
+++ b/neurodamus/commands.py
@@ -55,7 +55,8 @@ def neurodamus(args=None):
         --enable-shm=[ON, OFF]  Enables the use of /dev/shm for coreneuron_input [default: ON]
         --model-stats           Show model stats in CoreNEURON simulations [default: False]
         --dry-run               Dry-run simulation to estimate memory usage [default: False]
-        --prosp-hosts=<number>  Number of prospective hosts for dry-run load balancing [default: 40]
+        --num-target-ranks=<number>  Number of ranks to target for dry-run load balancing
+                                [default: 40]
     """
     options = docopt_sanitize(docopt(neurodamus.__doc__, args))
     config_file = options.pop("ConfigFile")

--- a/neurodamus/commands.py
+++ b/neurodamus/commands.py
@@ -55,6 +55,7 @@ def neurodamus(args=None):
         --enable-shm=[ON, OFF]  Enables the use of /dev/shm for coreneuron_input [default: ON]
         --model-stats           Show model stats in CoreNEURON simulations [default: False]
         --dry-run               Dry-run simulation to estimate memory usage [default: False]
+        --prosp-hosts=<number>  Number of prospective hosts for dry-run load balancing [default: 40]
     """
     options = docopt_sanitize(docopt(neurodamus.__doc__, args))
     config_file = options.pop("ConfigFile")

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -787,8 +787,10 @@ class ConnectionManagerBase(object):
             # Extrapolation
             logging.debug("Cells samples / total: %d / %s", sampled_gids_count, me_gids_count)
             me_estimated_sum = sum(metype_estimate.values())
+            average_syns_per_cell = me_estimated_sum / me_gids_count
+            self._dry_run_stats.average_syns_per_cell[metype] = average_syns_per_cell
             log_all(VERBOSE_LOGLEVEL, "%s: Average syns/cell: %.1f, Estimated total: %d ",
-                    metype, me_estimated_sum / me_gids_count, me_estimated_sum)
+                    metype, average_syns_per_cell, me_estimated_sum)
             local_counter.update(metype_estimate)
 
         return local_counter

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -744,12 +744,13 @@ class ConnectionManagerBase(object):
             return {}
 
         local_counter = Counter()
+        dst_pop_name = self._cell_manager.population_name
 
         # NOTE:
         #  - Estimation (and extrapolation) is performed per metype since properties can vary
         #  - Consider only the cells for the current target
 
-        for metype, me_gids in self._dry_run_stats.metype_gids.items():
+        for metype, me_gids in self._dry_run_stats.metype_gids[dst_pop_name].items():
             me_gids = set(me_gids).intersection(new_gids)
             me_gids_count = len(me_gids)
             if not me_gids_count:

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -76,6 +76,7 @@ class CliOptions(ConfigT):
     model_stats = False
     simulator = None
     dry_run = False
+    prosp_hosts = 40
 
     # Restricted Functionality support, mostly for testing
 
@@ -235,6 +236,7 @@ class _SimConfig(object):
     spike_location = "soma"
     spike_threshold = -30
     dry_run = False
+    prosp_hosts = 40
 
     _validators = []
     _requisitors = []
@@ -274,6 +276,7 @@ class _SimConfig(object):
         cls.modifications = compat.Map(cls._config_parser.parsedModifications or {})
         cls.cli_options = CliOptions(**(cli_options or {}))
         cls.dry_run = cls.cli_options.dry_run
+        cls.prosp_hosts = cls.cli_options.prosp_hosts
         # change simulator by request before validator and init hoc config
         if cls.cli_options.simulator:
             cls._parsed_run["Simulator"] = cls.cli_options.simulator

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -76,7 +76,7 @@ class CliOptions(ConfigT):
     model_stats = False
     simulator = None
     dry_run = False
-    prosp_hosts = 40
+    num_target_ranks = 40
 
     # Restricted Functionality support, mostly for testing
 
@@ -236,7 +236,7 @@ class _SimConfig(object):
     spike_location = "soma"
     spike_threshold = -30
     dry_run = False
-    prosp_hosts = 40
+    num_target_ranks = 40
 
     _validators = []
     _requisitors = []
@@ -276,7 +276,7 @@ class _SimConfig(object):
         cls.modifications = compat.Map(cls._config_parser.parsedModifications or {})
         cls.cli_options = CliOptions(**(cli_options or {}))
         cls.dry_run = cls.cli_options.dry_run
-        cls.prosp_hosts = cls.cli_options.prosp_hosts
+        cls.num_target_ranks = cls.cli_options.num_target_ranks
         # change simulator by request before validator and init hoc config
         if cls.cli_options.simulator:
             cls._parsed_run["Simulator"] = cls.cli_options.simulator

--- a/neurodamus/io/cell_readers.py
+++ b/neurodamus/io/cell_readers.py
@@ -98,7 +98,7 @@ def load_sonata(circuit_conf, all_gids, stride=1, stride_offset=0, *,
         # skip_metypes = set(dry_run_stats.metype_memory.keys())
         metype_gids, counts = _retrieve_unique_metypes(node_pop, all_gids)
         dry_run_stats.metype_counts += counts
-        dry_run_stats.metype_gids = metype_gids
+        dry_run_stats.metype_gids[node_population] = metype_gids
         gid_metype_bundle = list(metype_gids.values())
         gidvec = dry_run_distribution(gid_metype_bundle, stride, stride_offset, total_cells)
 

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1868,7 +1868,7 @@ class Neurodamus(Node):
             log_stage("============= DRY RUN (SKIP SIMULATION) =============")
             self._dry_run_stats.display_total()
             self._dry_run_stats.display_node_suggestions()
-            ranks = int(SimConfig.prosp_hosts)
+            ranks = int(SimConfig.num_target_ranks)
             self._dry_run_stats.collect_all_mpi()
             allocation, total_memory_per_rank = distribute_cells(self._dry_run_stats, ranks)
             print_allocation_stats(allocation, total_memory_per_rank)

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -32,6 +32,7 @@ from .target_manager import TargetSpec, TargetManager
 from .utils import compat
 from .utils.logging import log_stage, log_verbose, log_all
 from .utils.memory import DryRunStats, trim_memory, pool_shrink, free_event_queues, print_mem_usage
+from .utils.memory import print_allocation_stats
 from .utils.timeit import TimerManager, timeit
 from .core.coreneuron_configuration import CoreConfig
 from .io.sonata_config import ConnectionTypes
@@ -1871,16 +1872,7 @@ class Neurodamus(Node):
             ranks = int(SimConfig.prosp_hosts)
             self._dry_run_stats.collect_all_mpi()
             allocation, total_memory_per_rank = distribute_cells(self._dry_run_stats, ranks)
-            # TODO: split this print into a separate function and make it available
-            #       only when logging is on DEBUG level
-            if MPI.rank == 0:
-                print("Allocation: ", allocation)
-                print("Total memory per rank: ", total_memory_per_rank)
-                import statistics
-                values = list(total_memory_per_rank.values())
-                print("Mean: ", statistics.mean(values))
-                print("Median: ", statistics.median(values))
-                print("Stdev: ", statistics.stdev(values))
+            print_allocation_stats(allocation, total_memory_per_rank)
             return
         if not SimConfig.simulate_model:
             self.sim_init()

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1865,8 +1865,13 @@ class Neurodamus(Node):
         """
         if SimConfig.dry_run:
             log_stage("============= DRY RUN (SKIP SIMULATION) =============")
+            from .utils.memory import distribute_cells
             self._dry_run_stats.display_total()
             self._dry_run_stats.display_node_suggestions()
+            ranks = 40
+            allocation, total_memory_per_rank = distribute_cells(self._dry_run_stats, ranks)
+            print("Allocation: ", allocation)
+            print("Total memory per rank: ", total_memory_per_rank)
             return
         if not SimConfig.simulate_model:
             self.sim_init()

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1868,10 +1868,19 @@ class Neurodamus(Node):
             from .utils.memory import distribute_cells
             self._dry_run_stats.display_total()
             self._dry_run_stats.display_node_suggestions()
-            ranks = 40
+            ranks = int(SimConfig.prosp_hosts)
+            self._dry_run_stats.collect_all_mpi()
             allocation, total_memory_per_rank = distribute_cells(self._dry_run_stats, ranks)
-            print("Allocation: ", allocation)
-            print("Total memory per rank: ", total_memory_per_rank)
+            # TODO: split this print into a separate function and make it available
+            #       only when logging is on DEBUG level
+            if MPI.rank == 0:
+                print("Allocation: ", allocation)
+                print("Total memory per rank: ", total_memory_per_rank)
+                import statistics
+                values = list(total_memory_per_rank.values())
+                print("Mean: ", statistics.mean(values))
+                print("Median: ", statistics.median(values))
+                print("Stdev: ", statistics.stdev(values))
             return
         if not SimConfig.simulate_model:
             self.sim_init()

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -32,7 +32,7 @@ from .target_manager import TargetSpec, TargetManager
 from .utils import compat
 from .utils.logging import log_stage, log_verbose, log_all
 from .utils.memory import DryRunStats, trim_memory, pool_shrink, free_event_queues, print_mem_usage
-from .utils.memory import print_allocation_stats
+from .utils.memory import print_allocation_stats, export_allocation_stats, distribute_cells
 from .utils.timeit import TimerManager, timeit
 from .core.coreneuron_configuration import CoreConfig
 from .io.sonata_config import ConnectionTypes
@@ -1866,13 +1866,13 @@ class Neurodamus(Node):
         """
         if SimConfig.dry_run:
             log_stage("============= DRY RUN (SKIP SIMULATION) =============")
-            from .utils.memory import distribute_cells
             self._dry_run_stats.display_total()
             self._dry_run_stats.display_node_suggestions()
             ranks = int(SimConfig.prosp_hosts)
             self._dry_run_stats.collect_all_mpi()
             allocation, total_memory_per_rank = distribute_cells(self._dry_run_stats, ranks)
             print_allocation_stats(allocation, total_memory_per_rank)
+            export_allocation_stats(allocation, "allocation.bin")
             return
         if not SimConfig.simulate_model:
             self.sim_init()

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -32,7 +32,6 @@ from .target_manager import TargetSpec, TargetManager
 from .utils import compat
 from .utils.logging import log_stage, log_verbose, log_all
 from .utils.memory import DryRunStats, trim_memory, pool_shrink, free_event_queues, print_mem_usage
-from .utils.memory import print_allocation_stats, export_allocation_stats, distribute_cells
 from .utils.timeit import TimerManager, timeit
 from .core.coreneuron_configuration import CoreConfig
 from .io.sonata_config import ConnectionTypes
@@ -1870,9 +1869,7 @@ class Neurodamus(Node):
             self._dry_run_stats.display_node_suggestions()
             ranks = int(SimConfig.num_target_ranks)
             self._dry_run_stats.collect_all_mpi()
-            allocation, total_memory_per_rank = distribute_cells(self._dry_run_stats, ranks)
-            print_allocation_stats(allocation, total_memory_per_rank)
-            export_allocation_stats(allocation, "allocation.bin")
+            self._dry_run_stats.distribute_cells(ranks)
             return
         if not SimConfig.simulate_model:
             self.sim_init()

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -238,7 +238,7 @@ class SynapseMemoryUsage:
 
 class DryRunStats:
     _MEMORY_USAGE_FILENAME = "cell_memory_usage.json"
-    _ALLOCATION_FILENAME = "allocation.gz"
+    _ALLOCATION_FILENAME = "allocation.pkl.gz"
 
     def __init__(self) -> None:
         self.metype_memory = {}

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -206,7 +206,7 @@ def distribute_cells(dry_run_stats, num_ranks):
         # Update total memory and re-add to the heap
         heapq.heappush(ranks, (total_memory, rank_id))
 
-    if rank_memory or rank_allocation is None:
+    if rank_memory is None or rank_allocation is None:
         return {}, {}
 
     return rank_allocation, rank_memory

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -243,9 +243,9 @@ class DryRunStats:
     def __init__(self) -> None:
         self.metype_memory = {}
         self.average_syns_per_cell = {}
+        self.metype_gids = {}
         self.metype_counts = Counter()
         self.synapse_counts = Counter()
-        self.metype_gids = {}
         _, _, self.base_memory, _ = get_task_level_mem_usage()
 
     @run_only_rank0

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -299,6 +299,21 @@ def export_allocation_stats(rank_allocation, filename):
         logging.warning("Unable to export allocation stats: {}".format(e))
 
 
+@run_only_rank0
+def import_allocation_stats(filename):
+    """
+    Import allocation dictionary from serialized pickle file.
+    """
+    import pickle
+    try:
+        with open(filename, 'rb') as f:
+            rank_allocation = pickle.load(f)
+        return rank_allocation
+    except Exception as e:
+        logging.warning("Unable to import allocation stats: {}".format(e))
+        return None
+
+
 class SynapseMemoryUsage:
     ''' A small class that works as a lookup table
     for the memory used by each type of synapse.

--- a/tests/integration-e2e/test_dry_run_worflow.py
+++ b/tests/integration-e2e/test_dry_run_worflow.py
@@ -1,6 +1,12 @@
-from neurodamus.utils.memory import (distribute_cells,
-                                     export_allocation_stats,
-                                     import_allocation_stats)
+from neurodamus.utils.memory import import_allocation_stats, export_allocation_stats
+
+
+def convert_to_standard_types(obj):
+    """Converts an object containing defaultdicts of Vectors to standard Python types."""
+    result = {}
+    for node, vectors in obj.items():
+        result[node] = {key: list(vector) for key, vector in vectors.items()}
+    return result
 
 
 def test_dry_run_workflow(USECASE3):
@@ -29,9 +35,14 @@ def test_dry_run_workflow(USECASE3):
     assert nd._dry_run_stats.suggest_nodes(0.3) > 0
 
     # Test that the allocation works and can be saved and loaded
-    rank_allocation, _ = distribute_cells(nd._dry_run_stats, 2)
+    rank_allocation, _ = nd._dry_run_stats.distribute_cells(2)
     export_allocation_stats(rank_allocation, USECASE3 / "allocation.bin")
     rank_allocation = import_allocation_stats(USECASE3 / "allocation.bin")
+    rank_allocation_standard = convert_to_standard_types(rank_allocation)
 
-    expected_items = {'NodeA': {0: [3]}, 'NodeB': {1: [2]}}
-    assert rank_allocation == expected_items
+    expected_items = {
+        'NodeA': {0: [1, 2, 3]},
+        'NodeB': {1: [1, 2]}
+    }
+
+    assert rank_allocation_standard == expected_items

--- a/tests/integration-e2e/test_dry_run_worflow.py
+++ b/tests/integration-e2e/test_dry_run_worflow.py
@@ -36,8 +36,8 @@ def test_dry_run_workflow(USECASE3):
 
     # Test that the allocation works and can be saved and loaded
     rank_allocation, _ = nd._dry_run_stats.distribute_cells(2)
-    export_allocation_stats(rank_allocation, USECASE3 / "allocation.bin")
-    rank_allocation = import_allocation_stats(USECASE3 / "allocation.bin")
+    export_allocation_stats(rank_allocation, USECASE3 / "allocation.gz")
+    rank_allocation = import_allocation_stats(USECASE3 / "allocation.gz")
     rank_allocation_standard = convert_to_standard_types(rank_allocation)
 
     expected_items = {

--- a/tests/integration-e2e/test_dry_run_worflow.py
+++ b/tests/integration-e2e/test_dry_run_worflow.py
@@ -36,8 +36,8 @@ def test_dry_run_workflow(USECASE3):
 
     # Test that the allocation works and can be saved and loaded
     rank_allocation, _ = nd._dry_run_stats.distribute_cells(2)
-    export_allocation_stats(rank_allocation, USECASE3 / "allocation.gz")
-    rank_allocation = import_allocation_stats(USECASE3 / "allocation.gz")
+    export_allocation_stats(rank_allocation, USECASE3 / "allocation.pkl.gz")
+    rank_allocation = import_allocation_stats(USECASE3 / "allocation.pkl.gz")
     rank_allocation_standard = convert_to_standard_types(rank_allocation)
 
     expected_items = {

--- a/tests/integration-e2e/test_dry_run_worflow.py
+++ b/tests/integration-e2e/test_dry_run_worflow.py
@@ -23,3 +23,13 @@ def test_dry_run_workflow(USECASE3):
     }
     assert nd._dry_run_stats.metype_counts == expected_items
     assert nd._dry_run_stats.suggest_nodes(0.3) > 0
+
+    # Test that the dry run mode works with a pickle file
+    import pickle
+    try:
+        with open((str(USECASE3 / "allocation.bin")), 'rb') as f:
+            rank_allocation = pickle.load(f)
+    except Exception as e:
+        print("Unable to import allocation stats: {}".format(e))
+    expected_items = {'NodeA': {0: [3]}, 'NodeB': {1: [2]}}
+    assert rank_allocation == expected_items

--- a/tests/integration-e2e/test_dry_run_worflow.py
+++ b/tests/integration-e2e/test_dry_run_worflow.py
@@ -1,3 +1,7 @@
+from neurodamus.utils.memory import (distribute_cells,
+                                     export_allocation_stats,
+                                     import_allocation_stats)
+
 
 def test_dry_run_workflow(USECASE3):
     """
@@ -24,12 +28,10 @@ def test_dry_run_workflow(USECASE3):
     assert nd._dry_run_stats.metype_counts == expected_items
     assert nd._dry_run_stats.suggest_nodes(0.3) > 0
 
-    # Test that the dry run mode works with a pickle file
-    import pickle
-    try:
-        with open((str(USECASE3 / "allocation.bin")), 'rb') as f:
-            rank_allocation = pickle.load(f)
-    except Exception as e:
-        print("Unable to import allocation stats: {}".format(e))
+    # Test that the allocation works and can be saved and loaded
+    rank_allocation, _ = distribute_cells(nd._dry_run_stats, 2)
+    export_allocation_stats(rank_allocation, USECASE3 / "allocation.bin")
+    rank_allocation = import_allocation_stats(USECASE3 / "allocation.bin")
+
     expected_items = {'NodeA': {0: [3]}, 'NodeB': {1: [2]}}
     assert rank_allocation == expected_items


### PR DESCRIPTION
## Context
This MR includes new mechanisms to generate a detailed load balancing using the memory estimates generated by the dry run. It distributes all the gids of the circuit to a number of ranks specified using the `--num-target-ranks` CLI flag taking care of distributing so that the allocation of each rank is balanced. The system is based on a greedy algorithm, assigning cells in blocks of 10 to the emptiest rank available at that moment.

It also includes automatic pickling and gzipping of the allocation dictionary to `allocation.pkl.gz` file. Loading of the generated load balance will be integrated in a future MR.

## Scope
The MR briefly expands the capabilities of the dry run workflow with automatic load balancing and save to pickle file for future use. All the structure involved stay the same and no significant change is made to workflow.

## Testing
Most of the new functionalities should be automatically tested using the `test_dry_run_workflow` integration tests. In any case a specific test that loads the pickled `allocation.bin` file and checks against expected values was integrated.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
