### PR TITLE
Remove dependency on mvdtool

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -27,7 +27,6 @@ There are also optional dependencies required for some functionalities, so keep 
 - scipy
 - morphio
 - NEURON
-- mvdtool
 
 Nowadays all these dependencies can be found in PyPI, so it's not a big problem to meet them. Indeed, after a plain "pip install," you can already call the "neurodamus" entry point and inspect the usage.
 However, as mentioned, without a compiled model for Neuron, there's nothing much it can do. More on that later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 plotting=['matplotlib'] # only for Neurodamus HL API
-full=['scipy', 'morphio', 'NEURON', 'mvdtool']
+full=['scipy', 'morphio', 'NEURON']
 
 [project.scripts]
 neurodamus = "neurodamus.commands:neurodamus"

--- a/tests/scientific/test_projections.py
+++ b/tests/scientific/test_projections.py
@@ -153,7 +153,7 @@ def test_synapse_delay_override(sonata_config_file):
     # If the target simulator is CoreNEURON, read the soma voltage report
     if target_simulator == "CORENEURON":
         # Load soma voltage data from the report file
-        soma_report_path = Path(config_file.name).parent / "soma.h5"
+        soma_report_path = os.path.join(nd._run_conf["OutputRoot"], "soma.h5")
         voltage_vec = _read_sonata_soma_report(soma_report_path)
 
     # Find impact on voltage. See test_spont_minis for an explanation


### PR DESCRIPTION
## Context
The last commit has blocked the simulations with BlueConfig files, so we are now only support SONATA data format. `mvdtool` is used for reading old mvd3 node files which is no longer needed and can be removed. 

## Scope
This PR removes the dependency on `mvdtool` from the package configuration file (`pyproject.toml`). The relevant source functions will be cleaned up in the next PRs for further deprecating legacy/BlueConfig.   

## Testing
Existing tests

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
