### PR TITLE
[BBPBGLIB-1114] Apply offset to the gids before reading node file

### DIFF
--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -249,7 +249,9 @@ class CellManagerBase(_CellManager):
         logging.info(" -> Distributing target '%s' using Load-Balance", target_spec.name)
         self._binfo = load_balancer.load_balance_info(target_spec)
         # self._binfo has gidlist, but gids can appear multiple times
-        all_gids = numpy.unique(self._binfo.gids.as_numpy().astype("uint32"))
+        all_gids = numpy.unique(
+            self._binfo.gids.as_numpy().astype("uint32") - self._local_nodes.offset
+        )
         total_cells = len(all_gids)
         gidvec, me_infos, full_size = loader_f(self._circuit_conf, all_gids)
         return gidvec, me_infos, total_cells, full_size


### PR DESCRIPTION
## Context
Fixes longrun ci issue detected [here](https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-1114).

## Scope
Apply population offset to the gids before reading node file when reusing load balancer.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
