### PR TITLE
Atemerev/opts config

### DIFF
--- a/init.py
+++ b/init.py
@@ -9,24 +9,30 @@ from neurodamus import commands
 from neuron import h
 
 
-def main():
+def extract_arguments(args):
     """Get the options for neurodamus and launch it.
 
     We can't use positional arguments with special so we look for
     --configFile=FILE, which defaults to simulation_config.json
     """
     config_file = "simulation_config.json"
-
-    for i, arg in enumerate(sys.argv[1:]):
+    for i, arg in enumerate(args[1:]):
         if not arg.startswith("-"):
-            print("Positional arguments are not supported by init.py. Please specify --configFile=<config file> to\n"
-                  "run this script (or leave empty to use the default, ./simulation_config.json).", file=sys.stderr)
-            sys.exit(1)
+            raise ValueError("Positional arguments are not supported")
         elif arg.startswith("--configFile="):
             config_file = arg.split('=')[1]
             break
+    args = [config_file] + [x for x in args[1:] if not x.startswith("--configFile=")]
+    return args
 
-    args = [config_file] + [x for x in sys.argv[1:] if not x.startswith("--configFile=")]
+
+def main():
+    try:
+        args = extract_arguments(sys.argv)
+    except ValueError:
+        print("Positional arguments are not supported by init.py. Please specify --configFile=<config file> to\n"
+              "run this script (or leave empty to use the default, ./simulation_config.json).", file=sys.stderr)
+        sys.exit(1)
 
     return commands.neurodamus(args)
 

--- a/init.py
+++ b/init.py
@@ -6,7 +6,6 @@ All rights reserved
 """
 import sys
 from neurodamus import commands
-from neuron import h
 
 
 def extract_arguments(args):

--- a/init.py
+++ b/init.py
@@ -15,18 +15,18 @@ def main():
     We can't use positional arguments with special so we look for
     --configFile=FILE, which defaults to simulation_config.json
     """
-    first_argument_pos = 1
     config_file = "simulation_config.json"
 
-    for i, arg in enumerate(sys.argv):
-        if arg.endswith("init.py"):
-            first_argument_pos = i + 1
+    for i, arg in enumerate(sys.argv[1:]):
+        if not arg.startswith("-"):
+            print("Positional arguments are not supported by init.py. Please specify --configFile=<config file> to\n"
+                  "run this script (or leave empty to use the default, ./simulation_config.json).", file=sys.stderr)
+            sys.exit(1)
         elif arg.startswith("--configFile="):
             config_file = arg.split('=')[1]
-            first_argument_pos = i + 1
             break
 
-    args = [config_file] + sys.argv[first_argument_pos:]
+    args = [config_file] + [x for x in sys.argv[1:] if not x.startswith("--configFile=")]
 
     return commands.neurodamus(args)
 

--- a/init.py
+++ b/init.py
@@ -15,10 +15,8 @@ def main():
     args = []
     try:
         args = extract_arguments(sys.argv)
-    except ValueError:
-        logging.error("Positional arguments are not supported by init.py; please "
-                      "specify --configFile=<config> to run this script (or leave "
-                      "empty to use the default, ./simulation_config.json).")
+    except ValueError as err:
+        logging.error(err)
         return 1
 
     return commands.neurodamus(args)

--- a/init.py
+++ b/init.py
@@ -6,25 +6,9 @@ All rights reserved
 """
 import sys
 from neurodamus import commands
+from neurodamus.utils.cli import extract_arguments
 from neuron import h
 import logging
-
-
-def extract_arguments(args):
-    """Get the options for neurodamus and launch it.
-
-    We can't use positional arguments with special so we look for
-    --configFile=FILE, which defaults to simulation_config.json
-    """
-    config_file = "simulation_config.json"
-    for i, arg in enumerate(args[1:]):
-        if not arg.startswith("-"):
-            raise ValueError("Positional arguments are not supported")
-        elif arg.startswith("--configFile="):
-            config_file = arg.split('=')[1]
-            break
-    args = [config_file] + [x for x in args[1:] if not x.startswith("--configFile=")]
-    return args
 
 
 def main():
@@ -34,7 +18,7 @@ def main():
     except ValueError:
         logging.error("Positional arguments are not supported by init.py; please specify --configFile=<config> "
                       "to run this script (or leave empty to use the default, ./simulation_config.json).")
-        h.quit(1)
+        return 1
 
     return commands.neurodamus(args)
 

--- a/init.py
+++ b/init.py
@@ -6,6 +6,8 @@ All rights reserved
 """
 import sys
 from neurodamus import commands
+from neuron import h
+import logging
 
 
 def extract_arguments(args):
@@ -26,12 +28,13 @@ def extract_arguments(args):
 
 
 def main():
+    args = []
     try:
         args = extract_arguments(sys.argv)
     except ValueError:
-        print("Positional arguments are not supported by init.py. Please specify --configFile=<config file> to\n"
-              "run this script (or leave empty to use the default, ./simulation_config.json).", file=sys.stderr)
-        sys.exit(1)
+        logging.error("Positional arguments are not supported by init.py; please specify --configFile=<config> "
+                      "to run this script (or leave empty to use the default, ./simulation_config.json).")
+        h.quit(1)
 
     return commands.neurodamus(args)
 

--- a/init.py
+++ b/init.py
@@ -16,8 +16,9 @@ def main():
     try:
         args = extract_arguments(sys.argv)
     except ValueError:
-        logging.error("Positional arguments are not supported by init.py; please specify --configFile=<config> "
-                      "to run this script (or leave empty to use the default, ./simulation_config.json).")
+        logging.error("Positional arguments are not supported by init.py; please "
+                      "specify --configFile=<config> to run this script (or leave "
+                      "empty to use the default, ./simulation_config.json).")
         return 1
 
     return commands.neurodamus(args)

--- a/neurodamus/utils/cli.py
+++ b/neurodamus/utils/cli.py
@@ -1,17 +1,24 @@
-
-
 def extract_arguments(args):
     """Get the options for neurodamus and launch it.
 
     We can't use positional arguments with special so we look for
     --configFile=FILE, which defaults to simulation_config.json
     """
+    first_argument_pos = 1
+    init_py_reached = False
     config_file = "simulation_config.json"
-    for i, arg in enumerate(args[1:]):
-        if not arg.startswith("-"):
-            raise ValueError("Positional arguments are not supported")
-        elif arg.startswith("--configFile="):
+    for i, arg in enumerate(args):
+        if arg.startswith("--configFile="):
             config_file = arg.split('=')[1]
-            break
-    args = [config_file] + [x for x in args[1:] if not x.startswith("--configFile=")]
-    return args
+            continue
+        if not init_py_reached:
+            if arg.endswith("init.py"):
+                first_argument_pos = i + 1
+                init_py_reached = True
+            continue
+        elif not arg.startswith("-"):
+            raise ValueError("Positional arguments are not supported")
+
+    result_args = ([config_file] +
+                   [x for x in args[first_argument_pos:] if not x.startswith("--configFile=")])
+    return result_args

--- a/neurodamus/utils/cli.py
+++ b/neurodamus/utils/cli.py
@@ -17,7 +17,7 @@ def extract_arguments(args):
                 init_py_reached = True
             continue
         elif not arg.startswith("-"):
-            raise ValueError("Positional arguments are not supported")
+            raise ValueError(f"Positional arguments are not supported. Found positional argument: '{arg}'")
 
     result_args = ([config_file] +
                    [x for x in args[first_argument_pos:] if not x.startswith("--configFile=")])

--- a/neurodamus/utils/cli.py
+++ b/neurodamus/utils/cli.py
@@ -1,0 +1,17 @@
+
+
+def extract_arguments(args):
+    """Get the options for neurodamus and launch it.
+
+    We can't use positional arguments with special so we look for
+    --configFile=FILE, which defaults to simulation_config.json
+    """
+    config_file = "simulation_config.json"
+    for i, arg in enumerate(args[1:]):
+        if not arg.startswith("-"):
+            raise ValueError("Positional arguments are not supported")
+        elif arg.startswith("--configFile="):
+            config_file = arg.split('=')[1]
+            break
+    args = [config_file] + [x for x in args[1:] if not x.startswith("--configFile=")]
+    return args

--- a/neurodamus/utils/cli.py
+++ b/neurodamus/utils/cli.py
@@ -8,16 +8,19 @@ def extract_arguments(args):
     init_py_reached = False
     config_file = "simulation_config.json"
     for i, arg in enumerate(args):
-        if arg.startswith("--configFile="):
-            config_file = arg.split('=')[1]
-            continue
         if not init_py_reached:
             if arg.endswith("init.py"):
                 first_argument_pos = i + 1
                 init_py_reached = True
+            elif arg.startswith("--configFile="):
+                raise ValueError("Usage: ... init.py --configFile <config_file.json> ...")
             continue
+
         elif not arg.startswith("-"):
-            raise ValueError(f"Positional arguments are not supported. Found positional argument: '{arg}'")
+            raise ValueError("Positional arguments are not supported by init.py. "
+                             f"Found positional argument: '{arg}'")
+        elif arg.startswith("--configFile="):
+            config_file = arg.split('=')[1]
 
     result_args = ([config_file] +
                    [x for x in args[first_argument_pos:] if not x.startswith("--configFile=")])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ exclude=["tests"]
 [tool.pytest.ini_options]
 addopts = "--verbose"
 markers = ["slow: marks tests as slow"]
+pythonpath = [
+  "."
+]
 
 [tool.distutils.bdist_wheel]
 universal = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,6 @@ exclude=["tests"]
 [tool.pytest.ini_options]
 addopts = "--verbose"
 markers = ["slow: marks tests as slow"]
-pythonpath = [
-  "."
-]
 
 [tool.distutils.bdist_wheel]
 universal = 1

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import sys
-import unittest
 import unittest.mock
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import sys
 import unittest
+import unittest.mock
 
 
 class MockParallelExec:

--- a/tests/unit/test_init_py_config.py
+++ b/tests/unit/test_init_py_config.py
@@ -5,25 +5,25 @@ from neurodamus.utils.cli import extract_arguments
 _default_config_file = 'simulation_config.json'
 
 
-def test_init_empty(_mock_neuron):
+def test_init_empty():
     args = extract_arguments(['some/dir/init.py'])
     assert len(args) == 1
     assert args[0] == _default_config_file
 
 
-def test_init_non_positional(_mock_neuron):
+def test_init_non_positional():
     with pytest.raises(ValueError):
         extract_arguments(['init.py', 'simulation_config.json'])
 
 
-def test_init_config_only(_mock_neuron):
+def test_init_config_only():
     args = extract_arguments(['another/dir/init.py',
                               '--configFile=conf/my_config.json'])
     assert len(args) == 1
     assert args[0] == 'conf/my_config.json'
 
 
-def test_init_pass_options(_mock_neuron):
+def test_init_pass_options():
     args = extract_arguments(['another/dir/init.py', '--foo=bar',
                               '--configFile=conf/my_config.json',
                               '-v', '--baz=qux'])
@@ -32,3 +32,23 @@ def test_init_pass_options(_mock_neuron):
     assert args[1] == '--foo=bar'
     assert args[2] == '-v'
     assert args[3] == '--baz=qux'
+
+
+def test_init_first_args():
+    args = extract_arguments(['dplace', 'special' 'another/dir/init.py', '--foo=bar',
+                              '--configFile=conf/my_config.json',
+                              '-v', '--baz=qux'])
+    assert len(args) == 4
+    assert args[0] == 'conf/my_config.json'
+    assert args[1] == '--foo=bar'
+    assert args[2] == '-v'
+    assert args[3] == '--baz=qux'
+
+
+def test_init_early_config_file():
+    args = extract_arguments(['dplace', 'special', '--configFile=my_config.json', '--some=pre',
+                              'etc', 'dir/init.py', '--foo=bar', '-v'])
+    assert len(args) == 3
+    assert args[0] == 'my_config.json'
+    assert args[1] == '--foo=bar'
+    assert args[2] == '-v'

--- a/tests/unit/test_init_py_config.py
+++ b/tests/unit/test_init_py_config.py
@@ -1,30 +1,32 @@
 import pytest
 
-import init
-
 _default_config_file = 'simulation_config.json'
 
 
-def test_init_empty():
-    args = init.extract_arguments(['some/dir/init.py'])
+def test_init_empty(_mock_neuron):
+    from init import extract_arguments
+    args = extract_arguments(['some/dir/init.py'])
     assert len(args) == 1
     assert args[0] == _default_config_file
 
 
-def test_init_non_positional():
+def test_init_non_positional(_mock_neuron):
+    from init import extract_arguments
     with pytest.raises(ValueError):
-        init.extract_arguments(['init.py', 'simulation_config.json'])
+        extract_arguments(['init.py', 'simulation_config.json'])
 
 
-def test_init_config_only():
-    args = init.extract_arguments(['another/dir/init.py', '--configFile=conf/my_config.json'])
+def test_init_config_only(_mock_neuron):
+    from init import extract_arguments
+    args = extract_arguments(['another/dir/init.py', '--configFile=conf/my_config.json'])
     assert len(args) == 1
     assert args[0] == 'conf/my_config.json'
 
 
-def test_init_pass_options():
-    args = init.extract_arguments(['another/dir/init.py', '--foo=bar', '--configFile=conf/my_config.json',
-                                   '-v', '--baz=qux'])
+def test_init_pass_options(_mock_neuron):
+    from init import extract_arguments
+    args = extract_arguments(['another/dir/init.py', '--foo=bar', '--configFile=conf/my_config.json',
+                              '-v', '--baz=qux'])
     assert len(args) == 4
     assert args[0] == 'conf/my_config.json'
     assert args[1] == '--foo=bar'

--- a/tests/unit/test_init_py_config.py
+++ b/tests/unit/test_init_py_config.py
@@ -1,0 +1,32 @@
+import pytest
+
+import init
+
+_default_config_file = 'simulation_config.json'
+
+
+def test_init_empty():
+    args = init.extract_arguments(['some/dir/init.py'])
+    assert len(args) == 1
+    assert args[0] == _default_config_file
+
+
+def test_init_non_positional():
+    with pytest.raises(ValueError):
+        init.extract_arguments(['init.py', 'simulation_config.json'])
+
+
+def test_init_config_only():
+    args = init.extract_arguments(['another/dir/init.py', '--configFile=conf/my_config.json'])
+    assert len(args) == 1
+    assert args[0] == 'conf/my_config.json'
+
+
+def test_init_pass_options():
+    args = init.extract_arguments(['another/dir/init.py', '--foo=bar', '--configFile=conf/my_config.json',
+                                   '-v', '--baz=qux'])
+    assert len(args) == 4
+    assert args[0] == 'conf/my_config.json'
+    assert args[1] == '--foo=bar'
+    assert args[2] == '-v'
+    assert args[3] == '--baz=qux'

--- a/tests/unit/test_init_py_config.py
+++ b/tests/unit/test_init_py_config.py
@@ -17,13 +17,15 @@ def test_init_non_positional(_mock_neuron):
 
 
 def test_init_config_only(_mock_neuron):
-    args = extract_arguments(['another/dir/init.py', '--configFile=conf/my_config.json'])
+    args = extract_arguments(['another/dir/init.py',
+                              '--configFile=conf/my_config.json'])
     assert len(args) == 1
     assert args[0] == 'conf/my_config.json'
 
 
 def test_init_pass_options(_mock_neuron):
-    args = extract_arguments(['another/dir/init.py', '--foo=bar', '--configFile=conf/my_config.json',
+    args = extract_arguments(['another/dir/init.py', '--foo=bar',
+                              '--configFile=conf/my_config.json',
                               '-v', '--baz=qux'])
     assert len(args) == 4
     assert args[0] == 'conf/my_config.json'

--- a/tests/unit/test_init_py_config.py
+++ b/tests/unit/test_init_py_config.py
@@ -1,30 +1,28 @@
 import pytest
 
+from neurodamus.utils.cli import extract_arguments
+
 _default_config_file = 'simulation_config.json'
 
 
 def test_init_empty(_mock_neuron):
-    from init import extract_arguments
     args = extract_arguments(['some/dir/init.py'])
     assert len(args) == 1
     assert args[0] == _default_config_file
 
 
 def test_init_non_positional(_mock_neuron):
-    from init import extract_arguments
     with pytest.raises(ValueError):
         extract_arguments(['init.py', 'simulation_config.json'])
 
 
 def test_init_config_only(_mock_neuron):
-    from init import extract_arguments
     args = extract_arguments(['another/dir/init.py', '--configFile=conf/my_config.json'])
     assert len(args) == 1
     assert args[0] == 'conf/my_config.json'
 
 
 def test_init_pass_options(_mock_neuron):
-    from init import extract_arguments
     args = extract_arguments(['another/dir/init.py', '--foo=bar', '--configFile=conf/my_config.json',
                               '-v', '--baz=qux'])
     assert len(args) == 4

--- a/tests/unit/test_init_py_config.py
+++ b/tests/unit/test_init_py_config.py
@@ -46,9 +46,6 @@ def test_init_first_args():
 
 
 def test_init_early_config_file():
-    args = extract_arguments(['dplace', 'special', '--configFile=my_config.json', '--some=pre',
+    with pytest.raises(ValueError):
+        extract_arguments(['dplace', 'special', '--configFile=my_config.json', '--some=pre',
                               'etc', 'dir/init.py', '--foo=bar', '-v'])
-    assert len(args) == 3
-    assert args[0] == 'my_config.json'
-    assert args[1] == '--foo=bar'
-    assert args[2] == '-v'


### PR DESCRIPTION
## Context
Options handling by `init.py`: `special` only supports positional options. Attempting to specify a config file as a positional option led to confusing error messages.

Now, using positional options in init.py lead to an error message explaining that only keyword options are supported. --configFile can be used anywhere on the command line, the rest of the options are passed correctly to `neurodamus.commands`.

## Scope
Init.py is affected, no new dependencies added. Handling arguments is extracted to a function for unit testing.

## Testing
tests/unit/test_init_py_config.py

## Review
* [X] PR description is complete
* [X] Coding style (imports, function length, New functions, classes or files) are good
* [X] Unit/Scientific test added
* [N/A] Updated Readme, in-code, developer documentation
