### PR TITLE
Fix unit tests

### DIFF
--- a/neurodamus/__init__.py
+++ b/neurodamus/__init__.py
@@ -9,9 +9,9 @@
     `node`, `cell_distributor`, etc; and still depends on several low-level HOC files at runtime.
 """
 from __future__ import absolute_import
-import pkg_resources
+import importlib.metadata
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
+    __version__ = importlib.metadata.version(__name__)
 except Exception:
     __version__ = 'devel'
 

--- a/tests/integration-e2e/test_cli_opts.py
+++ b/tests/integration-e2e/test_cli_opts.py
@@ -35,7 +35,7 @@ def test_save_restore_cli():
             checkpoint_dir = test_folder_path / "output-save" / "checkpoint"
 
             command = ["neurodamus", test_folder_path / CONFIG_FILE_MINI,
-                        "--" + action, checkpoint_dir]
+                        "--" + action + "=" + str(checkpoint_dir)]
             # Save-Restore raises exception when using NEURON
             if simulator == "NEURON":
                 with pytest.raises(subprocess.CalledProcessError):


### PR DESCRIPTION
## Context
PR #115 has set checks on the command arguments so that positional arguments will be rejected. One of the unit test wasn't using the right `$NEURODAMUS_PYTHON/init.py` during the PR and thus failing now. 
And towards Python 3.12, `pkg_resources` will be deprecated and needs to be replaced. 

## Scope
This PR fixed the unit test in `test_cli_opts.py` by correcting the argument to "--save=PATH".
And it replaces `pkg_resources.get_distribution` with `importlib.metadata.version` 

## Testing
Existing tests

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
