### PR TITLE
StrEnum not working with older python versions

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -3,6 +3,17 @@ on:
   schedule:
     # every evening at 20:00 UTC
     - cron: '0 20 * * *'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      NEURON_BRANCH:
+        description: 'NEURON branch to use'
+        required: false
+      LIBSONATA_REPORT_BRANCH:
+        description: 'libsonatareport branch to use'
+        required: false
 
 jobs:
   simulation:

--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -5,10 +5,10 @@ import json
 import libsonata
 import logging
 import os.path
-from enum import StrEnum
+from enum import Enum
 
 
-class ConnectionTypes(StrEnum):
+class ConnectionTypes(str, Enum):
     Synaptic = "Synaptic"
     GapJunction = "GapJunction"
     NeuroModulation = "NeuroModulation"


### PR DESCRIPTION
## Context
The StrEnum type was introduced in python 3.11, so it was failing with previous python versions in the github actions.

## Scope
In this PR, StrEnum is replaced by inheriting not only from enum but also from str.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
