### PR TITLE
[BBPBGLIB-1122] Removing legacy RNGs, leaving only Random123

### DIFF
--- a/neurodamus/connection.py
+++ b/neurodamus/connection.py
@@ -714,36 +714,12 @@ class SpontMinis(ArtificialStim):
         self._store(ips, netcon)
 
         src_pop_id, dst_pop_id = conn.population_id
-        rng_mode = self._rng_info.getRNGMode()
         rng_seed = self._rng_info.getMinisSeed()
         tgid_seed = conn.tgid + 250
 
-        if rng_mode == self._rng_info.RANDOM123:
-            seed2 = (src_pop_id * 65536 + dst_pop_id + rng_seed)
-            ips.setRNGs(syn_obj.synapseID + 200, tgid_seed, seed2 + 300,
-                        syn_obj.synapseID + 200, tgid_seed, seed2 + 350)
-        else:
-            seed2 = src_pop_id * 16777216
-            exprng = Nd.Random()
-            if rng_mode == self._rng_info.COMPATIBILITY:
-                exprng.MCellRan4(syn_obj.synapseID * 100000 + 200,
-                                 tgid_seed + base_seed + rng_seed)
-            else:  # if ( rngIndo.getRNGMode()== rng_info.UPMCELLRAN4 ):
-                exprng.MCellRan4(syn_obj.synapseID * 1000 + 200,
-                                 seed2 + tgid_seed + base_seed + rng_seed)
-
-            exprng.negexp(1)
-            uniformrng = Nd.Random()
-            if rng_mode == self._rng_info.COMPATIBILITY:
-                uniformrng.MCellRan4(syn_obj.synapseID * 100000 + 300,
-                                     tgid_seed + base_seed + rng_seed)
-            else:  # if ( rngIndo.getRNGMode()== rng_info.UPMCELLRAN4 ):
-                uniformrng.MCellRan4(syn_obj.synapseID * 1000 + 300,
-                                     seed2 + tgid_seed + base_seed + rng_seed)
-
-            uniformrng.uniform(0.0, 1.0)
-            ips.setRNGs(exprng, uniformrng)
-            self._keep_alive += (exprng, uniformrng)
+        seed2 = (src_pop_id * 65536 + dst_pop_id + rng_seed)
+        ips.setRNGs(syn_obj.synapseID + 200, tgid_seed, seed2 + 300,
+                    syn_obj.synapseID + 200, tgid_seed, seed2 + 350)
 
     def __bool__(self):
         """object is considered False in case rate is not positive"""

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -108,8 +108,6 @@ class CircuitConfig(ConfigT):
 
 
 class RNGConfig(ConfigT):
-    Modes = Enum("Mode", "COMPATIBILITY RANDOM123 UPMCELLRAN4")
-    mode = Modes.COMPATIBILITY
     global_seed = None
     IonChannelSeed = None
     StimulusSeed = None

--- a/neurodamus/core/random.py
+++ b/neurodamus/core/random.py
@@ -11,7 +11,7 @@ from . import Neuron
 
 class RNG(object):
     def __new__(cls, **kw):
-        """Creates a default RNG, currently based on ACG"""
+        """Creates a default RNG (Random123 with ids of 0,1,2)"""
         seed = kw.get("seed", 0)
         return Random123(0, 1, 2, seed)
 

--- a/neurodamus/core/random.py
+++ b/neurodamus/core/random.py
@@ -10,9 +10,10 @@ from . import Neuron
 
 
 class RNG(object):
-    def __new__(cls):
-        """Creates a default RNG (Random123)"""
-        return Random123(0, 1, 2, 0)
+    def __new__(cls, **kw):
+        """Creates a default RNG, currently based on ACG"""
+        seed = kw.get("seed", 0)
+        return Random123(0, 1, 2, seed)
 
     @classmethod
     def create(cls, ids, seed=None):

--- a/neurodamus/core/random.py
+++ b/neurodamus/core/random.py
@@ -10,10 +10,9 @@ from . import Neuron
 
 
 class RNG(object):
-    def __new__(cls, *ids, **kw):
-        """Creates a default RNG (Random123) """
-        seed = kw.get("seed")
-        return Random123(ids[0], ids[1], ids[2], seed)
+    def __new__(cls):
+        """Creates a default RNG (Random123)"""
+        return Random123(0, 1, 2, 0)
 
     @classmethod
     def create(cls, ids, seed=None):

--- a/neurodamus/core/random.py
+++ b/neurodamus/core/random.py
@@ -3,54 +3,33 @@ Py Wrappers for the HOC RNGs
 """
 from __future__ import absolute_import
 from . import Neuron
-from neurodamus.core.configuration import RNGConfig
 
 
-# NOTE: These are pure wrappers, in the sense they dont create Python objects. Instead
+# NOTE: These are pure wrappers, in the sense they don't create Python objects. Instead
 #       Neuron objects are returned (using __new__)
 
 
 class RNG(object):
     def __new__(cls, *ids, **kw):
-        """Creates a default RNG, currently based on ACG"""
+        """Creates a default RNG (Random123) """
         seed = kw.get("seed")
-        return Neuron.h.Random() if seed is None else Neuron.h.Random(seed)
+        return Random123(ids[0], ids[1], ids[2], seed)
 
     @classmethod
-    def create(cls, rng_mode, ids, seed=None):
-        # type: (RNGConfig, tuple, object) -> RNG
-        if rng_mode == RNGConfig.Modes.RANDOM123:
-            assert len(ids) == 3, "Random123 requires three ids (as a tuple)"
-            obj = Random123(ids[0], ids[1], ids[2], seed)
-        elif rng_mode == RNGConfig.Modes.UPMCELLRAN4:
-            assert len(ids) == 1
-            obj = MCellRan4(ids[0], seed)
-        else:
-            obj = RNG(seed)
+    def create(cls, ids, seed=None):
+        # type: (tuple, object) -> RNG
+        assert len(ids) == 3, "Random123 requires three ids (as a tuple)"
+        obj = Random123(ids[0], ids[1], ids[2], seed)
 
         return obj
 
 
-class ACG(RNG):
-    def __new__(cls, size=None, seed=None):
-        rng = RNG(seed=seed)
-        rng.ACG(seed, size)
-        return rng
-
-
 class Random123(RNG):
     def __new__(cls, id1, id2, id3, seed=None):
-        rng = RNG()
+        rng = Neuron.h.Random() if seed is None else Neuron.h.Random(seed)
         if seed is not None:
             rng.Random123_globalindex(seed)
         rng.Random123(id1, id2, id3)
-        return rng
-
-
-class MCellRan4(RNG):
-    def __new__(cls, high_i, seed=None, low_i=0):
-        rng = RNG(seed=seed)
-        rng.MCellRan4(high_i, low_i)
         return rng
 
 

--- a/neurodamus/data/hoc/RNGSettings.hoc
+++ b/neurodamus/data/hoc/RNGSettings.hoc
@@ -7,6 +7,7 @@
  */
 {load_file("fileUtils.hoc")}
 
+rngMode = 1  // corresponds to RANDOM123 defined below
 ionchannelSeed = 0
 synapseSeed = 0
 stimulusSeed = 0
@@ -15,11 +16,14 @@ globalSeed = 0
 
 begintemplate RNGSettings
 
-public init, interpret, getIonChannelSeed, getSynapseSeed, getStimulusSeed, getMinisSeed, getGlobalSeed
+public init, interpret, getRNGMode, getIonChannelSeed, getSynapseSeed, getStimulusSeed, getMinisSeed, getGlobalSeed
+public RANDOM123
 
-external ionchannelSeed, synapseSeed, stimulusSeed, minisSeed, globalSeed, terminate
+external rngMode, ionchannelSeed, synapseSeed, stimulusSeed, minisSeed, globalSeed, terminate
 
 proc init() {
+    // consts for random number handling
+    RANDOM123 = 1
 }
 
 /**
@@ -31,6 +35,7 @@ proc init() {
 proc interpret() { local coreNeuronUsed localobj runInfo, pc, rng
     strdef rngModeField
     runInfo = $o1
+    rngMode = RANDOM123
     coreNeuronUsed = $2
     if (numarg() < 2) {
         coreNeuronUsed = 0
@@ -39,6 +44,15 @@ proc interpret() { local coreNeuronUsed localobj runInfo, pc, rng
     pc = new ParallelContext()
     if( pc.id() == 0 ) {
         print "As of Oct 2020 Neurodamus uses Random123 as default"
+    }
+
+    if( runInfo.exists( "RNGMode" ) ) {
+        rngModeField = runInfo.get( "RNGMode" ).s
+        if( strcmp( rngModeField, "Random123" ) == 0 ) {
+            rngMode = RANDOM123
+        } else {
+            terminate( "Invalid RNGMode (only Random123 is currently supported) ", rngModeField )
+        }
     }
 
     if( runInfo.exists("BaseSeed") ) {
@@ -61,6 +75,10 @@ proc interpret() { local coreNeuronUsed localobj runInfo, pc, rng
     if( runInfo.exists("SynapseSeed") ) {
         synapseSeed = runInfo.valueOf( "SynapseSeed" )
     }
+}
+
+func getRNGMode() {
+    return rngMode
 }
 
 func getIonChannelSeed() {

--- a/neurodamus/data/hoc/RNGSettings.hoc
+++ b/neurodamus/data/hoc/RNGSettings.hoc
@@ -7,7 +7,6 @@
  */
 {load_file("fileUtils.hoc")}
 
-rngMode = 0  // corresponds to COMPATIBILITY defined below
 ionchannelSeed = 0
 synapseSeed = 0
 stimulusSeed = 0
@@ -16,16 +15,11 @@ globalSeed = 0
 
 begintemplate RNGSettings
 
-public init, interpret, getRNGMode, getIonChannelSeed, getSynapseSeed, getStimulusSeed, getMinisSeed, getGlobalSeed
-public COMPATIBILITY, RANDOM123, UPMCELLRAN4
+public init, interpret, getIonChannelSeed, getSynapseSeed, getStimulusSeed, getMinisSeed, getGlobalSeed
 
-external rngMode, ionchannelSeed, synapseSeed, stimulusSeed, minisSeed, globalSeed, terminate
+external ionchannelSeed, synapseSeed, stimulusSeed, minisSeed, globalSeed, terminate
 
 proc init() {
-    // consts for random number handling
-    COMPATIBILITY = 0
-    RANDOM123 = 1
-    UPMCELLRAN4 = 2
 }
 
 /**
@@ -37,7 +31,6 @@ proc init() {
 proc interpret() { local coreNeuronUsed localobj runInfo, pc, rng
     strdef rngModeField
     runInfo = $o1
-    rngMode = RANDOM123
     coreNeuronUsed = $2
     if (numarg() < 2) {
         coreNeuronUsed = 0
@@ -48,42 +41,14 @@ proc interpret() { local coreNeuronUsed localobj runInfo, pc, rng
         print "As of Oct 2020 Neurodamus uses Random123 as default"
     }
 
-    if( runInfo.exists( "RNGMode" ) ) {
-        rngModeField = runInfo.get( "RNGMode" ).s
-        if( strcmp( rngModeField, "Compatibility" ) == 0 ) {
-            rngMode = COMPATIBILITY
-        } else if( strcmp( rngModeField, "UpdatedMCell" ) == 0 ) {
-            rngMode = UPMCELLRAN4
-        } else if( strcmp( rngModeField, "Random123" ) == 0 ) {
-            rngMode = RANDOM123
-        } else {
-            terminate( "Invalid RNGMode ", rngModeField )
-        }
-        if( pc.id() == 0 ) {
-            print "RNGMode set to ", rngMode, " [COMPATIBILITY=0, RANDOM123=1, UPMCELLRAN4=2]"
-        }
-    }
-
-    if( coreNeuronUsed && rngMode != RANDOM123) {
-        // Given R123 is now the default there's no sense to allow an explicit invalid option
-        terminate( "Config Error: CoreNEURON requires Random123 RNG" )
-    }
-
     if( runInfo.exists("BaseSeed") ) {
         globalSeed = runInfo.valueOf( "BaseSeed" )
 
         // random123 can set the global index now
-        if( rngMode == RANDOM123 ) {
-            rng = new Random()
-            rng.Random123_globalindex( globalSeed )
-        }
+        rng = new Random()
+        rng.Random123_globalindex( globalSeed )
     }
     
-    // don't search for indicidual seeds if we are in compatibility mode
-    if( rngMode == COMPATIBILITY ) {
-        return
-    }
-
     if( runInfo.exists("IonChannelSeed") ) {
         ionchannelSeed = runInfo.valueOf( "IonChannelSeed" )
     }
@@ -96,10 +61,6 @@ proc interpret() { local coreNeuronUsed localobj runInfo, pc, rng
     if( runInfo.exists("SynapseSeed") ) {
         synapseSeed = runInfo.valueOf( "SynapseSeed" )
     }
-}
-
-func getRNGMode() {
-    return rngMode
 }
 
 func getIonChannelSeed() {
@@ -123,120 +84,3 @@ func getGlobalSeed() {
 }
 
 endtemplate RNGSettings
-
-
-///////////////////////////////////////////////////////////////////////
-///
-///  These are legacy functions to keep compaltibility
-///
-///////////////////////////////////////////////////////////////////////
-
-/*!
- * In place of using a CCell's re_init_rng function, we will check for cells that define the re_init_rng function,
- * but then setRNG using global seed as well
- *
- * @param $o1 CCell which is to be checked for setRNG
- */
-obfunc rngForStochKvInit() {  local channelID, hasStochKv  localobj CCell, rng, rngInfo, rngList, pc
-    CCell = $o1
-    //print "Replace rng for stochKv in gid ", CCell.CellRef.gid
-
-    // quick check to verify this object contains StochKv
-    hasStochKv = 0
-    CCell.CellRef.soma {
-        if( ismembrane( "StochKv" ) ) {
-            hasStochKv = 1
-        }
-    }
-
-    if( !hasStochKv ) {
-        return
-    }
-
-    rngList = new List()
-
-    channelID = 0
-    forsec CCell.CellRef.somatic {
-        for (x, 0) {
-            setdata_StochKv(x)
-            rng = new Random()
-            rng.MCellRan4( channelID*10000+100, globalSeed + ionchannelSeed + CCell.CellRef.gid*10000+250+1 )
-            channelID = channelID + 1
-            rng.uniform(0,1)
-            setRNG_StochKv(rng)
-            rngList.append(rng)
-        }
-    }
-    forsec CCell.CellRef.basal {
-        for (x, 0) {
-            setdata_StochKv(x)
-            rng = new Random()
-            rng.MCellRan4( channelID*10000+100, globalSeed + ionchannelSeed + CCell.CellRef.gid*10000+250+1 )
-            channelID = channelID + 1
-            rng.uniform(0,1)
-            setRNG_StochKv(rng)
-            rngList.append(rng)
-        }
-    }
-    forsec CCell.CellRef.apical {
-        for (x, 0) {
-            setdata_StochKv(x)
-            rng = new Random()
-            rng.MCellRan4( channelID*10000+100, globalSeed + ionchannelSeed + CCell.CellRef.gid*10000+250+1 )
-            channelID = channelID + 1
-            rng.uniform(0,1)
-            setRNG_StochKv(rng)
-            rngList.append(rng)
-        }
-    }
-
-    return rngList
-}
-
-//-----------------------------------------------------------------------------------------------
-
-/*!
- * In place of using a CCell's re_init_rng function, we will check for cells that define the re_init_rng function,
- * but then setRNG using random123
- *
- * @param $o1 CCell which is to be checked for setRNG
- */
-proc rng123ForStochKvInit() {  local channelID, hasStochKv  localobj CCell
-    CCell = $o1
-    //print "Replace rng for stochKv in gid ", CCell.CellRef.gid
-
-    // quick check to verify this object contains StochKv
-    hasStochKv = 0
-    CCell.CellRef.soma {
-        if( ismembrane( "StochKv" ) ) {
-            hasStochKv = 1
-        }
-    }
-
-    if( !hasStochKv ) {
-        return
-    }
-
-    channelID = 0
-    forsec CCell.CellRef.somatic {
-        for (x, 0) {
-            setdata_StochKv(x)
-            setRNG_StochKv(ionchannelSeed, channelID, CCell.CellRef.gid + 1)
-            channelID = channelID + 1
-        }
-    }
-    forsec CCell.CellRef.basal {
-        for (x, 0) {
-            setdata_StochKv(x)
-            setRNG_StochKv(ionchannelSeed, channelID, CCell.CellRef.gid + 1)
-            channelID = channelID + 1
-        }
-    }
-    forsec CCell.CellRef.apical {
-        for (x, 0) {
-            setdata_StochKv(x)
-            setRNG_StochKv(ionchannelSeed, channelID, CCell.CellRef.gid + 1)
-            channelID = channelID + 1
-        }
-    }
-}

--- a/neurodamus/stimulus_manager.py
+++ b/neurodamus/stimulus_manager.py
@@ -551,15 +551,11 @@ class Noise(BaseStim):
         self.parse_check_all_parameters(stim_info)
 
         sim_dt = float(SimConfig.run_conf["Dt"])  # simulation time-step [ms]
-        rng_mode = SimConfig.rng_info.getRNGMode()  # simulation RNGMode
 
         # setup RNG
-        if rng_mode == SimConfig.rng_info.RANDOM123:
-            rand = lambda gid: random.Random123(Noise.stimCount + 100,
-                                                SimConfig.rng_info.getStimulusSeed() + 500,
-                                                gid + 300)
-        else:
-            raise Exception("rng_mod is not RANDOM123")
+        rand = lambda gid: random.Random123(Noise.stimCount + 100,
+                                            SimConfig.rng_info.getStimulusSeed() + 500,
+                                            gid + 300)
 
         # apply stim to each point in target
         tpoints = target.getPointList(cell_manager)

--- a/tests/integration/test_neuron.py
+++ b/tests/integration/test_neuron.py
@@ -15,4 +15,4 @@ def test_base_h():
 def neurodamus():
     from neurodamus.core import NeurodamusCore as Nd
     rng_conf = Nd.RNGSettings()
-    assert rng_conf.RANDOM123 == 1
+    assert rng_conf.getGlobalSeed() == 0


### PR DESCRIPTION
Removing legacy RNGs and the ability to configure RNGs. Random123 is chosen everywhere as the only option.

## Context

RNG types differing from Random123 are no longer used and removed from everywhere (including configuration).

## Scope

RNGSettings.hoc (removed RNGmode and all related constants), configuration.py, random.py, and corresponding usages.

## Testing

Write a test that raises exception in attempt to configure RNG mode.

## Review
* [X] PR description is complete
* [X] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
