### PR TITLE
Fix fetching error in GH workflow triggered by tag and ChangeLog for 3.1.1

### DIFF
--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 500
-          fetch-tags: true
       - name: Build Wheel
         run: |
           cd $GITHUB_WORKSPACE

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Change Log
 ==========
 
+Version 3.1.1
+=============
+**12 Mar 2024**
+
+*Bug Fixes*
+  * Fix fetching error in GH workflow triggered by tag
+
+
 Version 3.1.0
 =============
 **12 Mar 2024**


### PR DESCRIPTION
## Context
This PR fixes the fetching error seen in the GH workflow triggered by tag.

## Scope
Remove "fetch-tags: true" in actions/checkout@v4

## Testing
<!--
Please add a new test under `tests`. Consider the following cases:

 1. If the change is in an independent component (e.g, a new container type, a parser, etc) a bare unit test should be sufficient. See e.g. `tests/test_coords.py`
 2. If you are fixing or adding components supporting a scientific use case, affecting node or synapse creation, etc..., which typically rely on Neuron, tests should set up a simulation using that feature, instantiate neurodamus, **assess the state**, run the simulation and check the results are as expected.
    See an example at `tests/test_simulation.py#L66`
-->

## Review
* [x] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
