### PR TITLE
[BBPBGLIB-1145] Different ordering of circuits causes inconsistent offsets

### DIFF
--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -46,7 +46,7 @@ class VirtualCellPopulation:
         """
         self.population_name = population_name
         self.circuit_target = circuit_target
-        self.local_nodes = NodeSet(gids).register_global(population_name or '')
+        self.local_nodes = NodeSet(gids).register_global(population_name or '', is_virtual=True)
         VirtualCellPopulation._total_count += 1
         if VirtualCellPopulation._total_count > 1:
             logging.warning("For non-sonata circuit, "

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -588,7 +588,14 @@ def _extra_circuits(config: _SimConfig, run_conf):
     # Sort so that iteration is deterministic
     config.extra_circuits = dict(sorted(
         extra_circuits.items(),
-        key=lambda x: (x[1].Engine.CircuitPrecedence if x[1].Engine else 0, x[0])
+        key=lambda x: (
+            # Circuits with Engine go first
+            x[1].Engine.CircuitPrecedence if x[1].Engine else float('inf'),
+            # Then circuits without virtual populations
+            0 if x[1].get("PopulationType", False) != "virtual" else 1,
+            # Circuit identifier as tiebreaker
+            x[0]
+        )
     ))
 
 

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -588,14 +588,7 @@ def _extra_circuits(config: _SimConfig, run_conf):
     # Sort so that iteration is deterministic
     config.extra_circuits = dict(sorted(
         extra_circuits.items(),
-        key=lambda x: (
-            # Circuits with Engine go first
-            x[1].Engine.CircuitPrecedence if x[1].Engine else float('inf'),
-            # Then circuits without virtual populations
-            0 if x[1].get("PopulationType", False) != "virtual" else 1,
-            # Circuit identifier as tiebreaker
-            x[0]
-        )
+        key=lambda x: (x[1].Engine.CircuitPrecedence if x[1].Engine else 0, x[0])
     ))
 
 

--- a/neurodamus/core/nodeset.py
+++ b/neurodamus/core/nodeset.py
@@ -90,7 +90,8 @@ class PopulationNodes:
         base_pop, other_pops = [], cls._global_populations
         if cls._has_base_population:
             base_pop, other_pops = cls._global_populations[0:1], cls._global_populations[1:]
-        cls._global_populations = base_pop + sorted(other_pops, key=lambda x: x.name)
+        # Keep the order from the _extra_circuits dictionary
+        cls._global_populations = base_pop + other_pops
         new_population._compute_offset(cls._find_previous(new_population))
         return new_population
 

--- a/neurodamus/core/nodeset.py
+++ b/neurodamus/core/nodeset.py
@@ -90,8 +90,7 @@ class PopulationNodes:
         base_pop, other_pops = [], cls._global_populations
         if cls._has_base_population:
             base_pop, other_pops = cls._global_populations[0:1], cls._global_populations[1:]
-        # Keep the order from the _extra_circuits dictionary
-        cls._global_populations = base_pop + other_pops
+        cls._global_populations = base_pop + sorted(other_pops, key=lambda x: x.name)
         new_population._compute_offset(cls._find_previous(new_population))
         return new_population
 

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -362,56 +362,55 @@ class Node:
             logging.info(" => No circuit for Load Balancing. Skipping... ")
             return None
 
-        with PopulationNodes.offset_freezer():  # Dont offset while in loadbal
-            # Info about the cells to be distributed
-            target_spec = TargetSpec(circuit.CircuitTarget)
-            target = self.target_manager.get_target(target_spec)
+        _ = PopulationNodes.offset_freezer()  # Dont offset while in loadbal
 
-            # Check / set load balance mode
-            lb_mode = LoadBalance.select_lb_mode(SimConfig, self._run_conf, target)
-            if lb_mode == LoadBalanceMode.RoundRobin:
-                return None
-            elif lb_mode == LoadBalanceMode.Memory:
-                logging.info("Load Balancing ENABLED. Mode: Memory")
-                alloc = import_allocation_stats("allocation.pkl.gz")
-                for pop, ranks in alloc.items():
-                    for rank, gids in ranks.items():
-                        logging.debug("Population: %s, Rank: %s, Number of GIDs: %s",
-                                      pop, rank, len(gids))
-                if MPI.rank == 0:
-                    unique_ranks = set(rank for pop in alloc.values() for rank in pop.keys())
-                    logging.debug("Unique ranks in allocation file: %s", len(unique_ranks))
-                    if MPI.size != len(unique_ranks):
-                        raise ConfigurationError(
-                            "The number of ranks in the allocation file is different from the "
-                            "number of ranks in the current run. The allocation file was created "
-                            "with a different number of ranks."
-                        )
-                return alloc
+        # Info about the cells to be distributed
+        target_spec = TargetSpec(circuit.CircuitTarget)
+        target = self.target_manager.get_target(target_spec)
 
-            # Build load balancer as per requested options
-            data_src = circuit.CircuitPath
-            pop = target_spec.population
-            load_balancer = LoadBalance(lb_mode, data_src, pop, self._target_manager)
+        # Check / set load balance mode
+        lb_mode = LoadBalance.select_lb_mode(SimConfig, self._run_conf, target)
+        if lb_mode == LoadBalanceMode.RoundRobin:
+            return None
+        elif lb_mode == LoadBalanceMode.Memory:
+            logging.info("Load Balancing ENABLED. Mode: Memory")
+            alloc = import_allocation_stats("allocation.pkl.gz")
+            for pop, ranks in alloc.items():
+                for rank, gids in ranks.items():
+                    logging.debug(f"Population: {pop}, Rank: {rank}, Number of GIDs: {len(gids)}")
+            if MPI.rank == 0:
+                unique_ranks = set(rank for pop in alloc.values() for rank in pop.keys())
+                logging.debug("Unique ranks in allocation file: %s", len(unique_ranks))
+                if MPI.size != len(unique_ranks):
+                    raise ConfigurationError(
+                        "The number of ranks in the allocation file is different from the number "
+                        "of ranks in the current run. The allocation file was created with a "
+                        "different number of ranks."
+                    )
+            return alloc
 
-            if load_balancer.valid_load_distribution(target_spec):
-                logging.info("Load Balancing done.")
-                return load_balancer
+        # Build load balancer as per requested options
+        data_src = circuit.CircuitPath
+        pop = target_spec.population
+        load_balancer = LoadBalance(lb_mode, data_src, pop, self._target_manager)
 
-            logging.info("Could not reuse load balance data. Doing a Full Load-Balance")
-            cell_dist = self._circuits.new_node_manager(
-                circuit, self._target_manager, self._run_conf)
-            with load_balancer.generate_load_balance(target_spec, cell_dist):
-                # Instantiate a basic circuit to evaluate complexities
-                cell_dist.finalize()
-                self._circuits.global_manager.finalize()
-                SimConfig.update_connection_blocks(self._circuits.alias)
-                target_manager = self._target_manager
-                self._create_synapse_manager(SynapseRuleManager, self._base_circuit, target_manager)
+        if load_balancer.valid_load_distribution(target_spec):
+            logging.info("Load Balancing done.")
+            return load_balancer
 
-            # reset since we instantiated with RR distribution
-            Nd.t = .0  # Reset time
-            self.clear_model()
+        logging.info("Could not reuse load balance data. Doing a Full Load-Balance")
+        cell_dist = self._circuits.new_node_manager(circuit, self._target_manager, self._run_conf)
+        with load_balancer.generate_load_balance(target_spec, cell_dist):
+            # Instantiate a basic circuit to evaluate complexities
+            cell_dist.finalize()
+            self._circuits.global_manager.finalize()
+            SimConfig.update_connection_blocks(self._circuits.alias)
+            target_manager = self._target_manager
+            self._create_synapse_manager(SynapseRuleManager, self._base_circuit, target_manager)
+
+        # reset since we instantiated with RR distribution
+        Nd.t = .0  # Reset time
+        self.clear_model()
 
         return load_balancer
 


### PR DESCRIPTION
## Context
Currently, circuits are sorted based on their population names.
During the load balancing process, circuits containing virtual populations are excluded. For the non-virtual circuits, the necessary complexity files are generated, which include specific offsets for the gids.

However, when it comes to loading the nodes, circuits with virtual populations are still considered and, due to the sorting order, may precede non-virtual circuits. This precedence can lead to a discrepancy: the offsets applied during node loading might not align with the offsets defined in the complexity files for non-virtual circuits. This misalignment results in inconsistencies between the calculated load balancing offsets and the actual offsets used during simulation initialization.

## Scope
To ensure consistency, the idea is, when sorting the circuits, to prioritize the ones without virtual populations and then having the same ordering when loading nodes.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
