### PR TITLE
[BBPBGLIB-1139] config / model error logging fix, stage 2

### DIFF
--- a/tests/simulations/usecase3/simulation_sonata.json
+++ b/tests/simulations/usecase3/simulation_sonata.json
@@ -1,5 +1,5 @@
 {
-    "version": 1,
+    "version": QQQ,
     "manifest": {
         "$OUTPUT_DIR": "./reporting",
         "$INPUT_DIR": "./"

--- a/tests/simulations/usecase3/simulation_sonata.json
+++ b/tests/simulations/usecase3/simulation_sonata.json
@@ -1,5 +1,5 @@
 {
-    "version": QQQ,
+    "version": 1,
     "manifest": {
         "$OUTPUT_DIR": "./reporting",
         "$INPUT_DIR": "./"


### PR DESCRIPTION
## Context

On simulation launch in commands.py, exceptions were handled in the same way for configuration / model loading errors, and simulation errors. This required quirky synchronization to make sure that exceptions were logged only at a single MPI node, otherwise they flood the output.

The idea of this PR is to separate exception handling for configuration parsing / model loading (these errors are the same for all nodes, and supposed to be logged only at the master node), and simulation errors (can happen only at some runs, and can be different everywhere, and perhaps need to be logged at all nodes).

## Scope

Separate exception handling at model loading stage and simulation run stage. Call _mpi_abort only in the latter case. In the former case, log errors only on the node with the MPI rank 0.

## Testing

Again, I don't think it is feasible to write a unit test for this.

## Review
* [X] PR description is complete
* [X] Coding style (imports, function length, New functions, classes or files) are good
* [N/A] Unit/Scientific test added
* [X] Updated Readme, in-code, developer documentation
