### PR TITLE
[BBPBGLIB-739] Override UTF-8 for logging

### DIFF
--- a/neurodamus/utils/timeit.py
+++ b/neurodamus/utils/timeit.py
@@ -117,6 +117,7 @@ from math import log, floor
 from .logging import log_verbose
 from ..core import NeurodamusCore as Nd, MPI, run_only_rank0
 
+logging.basicConfig(encoding='utf-8')  # override locale encoding; even if UTF-8 is not supported for output, it's OK
 
 def human_readable(num):
     """ Get a human readable version of a number.

--- a/neurodamus/utils/timeit.py
+++ b/neurodamus/utils/timeit.py
@@ -117,6 +117,7 @@ from math import log, floor
 from .logging import log_verbose
 from ..core import NeurodamusCore as Nd, MPI, run_only_rank0
 
+
 def human_readable(num):
     """ Get a human readable version of a number.
     For example: 5200000 -> 5.20M

--- a/neurodamus/utils/timeit.py
+++ b/neurodamus/utils/timeit.py
@@ -132,7 +132,7 @@ def human_readable(num):
         else str(int(num))
 
 
-delim = u'\u255a'
+delim = '+'
 
 
 class _Timer(object):

--- a/neurodamus/utils/timeit.py
+++ b/neurodamus/utils/timeit.py
@@ -117,8 +117,6 @@ from math import log, floor
 from .logging import log_verbose
 from ..core import NeurodamusCore as Nd, MPI, run_only_rank0
 
-logging.basicConfig(encoding='utf-8')  # override locale encoding; even if UTF-8 is not supported for output, it's OK
-
 def human_readable(num):
     """ Get a human readable version of a number.
     For example: 5200000 -> 5.20M


### PR DESCRIPTION
## Context

In timeit.py logging, a Unicode symbol \u255a (╚ ) is used to draw the tree hierarchy of time intervals measured. For logging in Python, 'locale' encoding is used by default. If the terminal locale is set to anything except UTF-8 (e.g. 'latin-1'), Python's output codec cannot encode the symbol, and fails with UnicodeEncodeError exception.

## Scope

The following solutions were considered:

1) Use an ASCII symbol instead of ╚, so it could work everywhere. 

The alternatives are "+", "=", and "L", but everything looks sort of ugly. We can also draw multi-line trees with |, + and -, but it takes a lot of more space and looks sort of ugly as well.

2) Force the UTF-8 encoded output.

Most terminals everywhere now support UTF-8. If they are misconfigured to other locale like latin-1, or genuinely do not support UTF-8, the symbol will be rendered as '?', which is ugly, but readable, and it does not mangles the output.

3) Read the locale-default encoding, and use an ASCII-based symbol as a separator if it is not UTF-8.

Output encoding determination can be unreliable, and it is prone to misconfiguration. 

* * *
I propose option 2.

## Testing

As it requires interaction with the terminal, I think manual testing is reasonable here.

## Review
* [X] PR description is complete
* [X] Coding style (imports, function length, New functions, classes or files) are good
* [N/A] Unit/Scientific test added
* [X] Updated Readme, in-code, developer documentation
