### PR TITLE
[BBPGBLIB-1147] Fixes crashes with KeyError when running sonataconf-sscx-O1 circuit on dry run

### DIFF
--- a/neurodamus/io/cell_readers.py
+++ b/neurodamus/io/cell_readers.py
@@ -192,7 +192,7 @@ def load_sonata(circuit_conf, all_gids, stride=1, stride_offset=0, *,
             prop_data = node_pop.get_dynamics_attribute(prop_name, node_sel)
         else:
             prop_data = node_pop.get_attribute(prop_name, node_sel)
-        for gid, val in zip(gidvec, prop_data):
+        for gid, val in zip(meinfos.keys(), prop_data):
             meinfos[gid].extra_attrs[prop_name] = val
 
     return gidvec, meinfos, fullsize


### PR DESCRIPTION
## Context
Fixes the crash when running sonataconf-sscx-O1 circuit on dry run as detailed in: https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-1147
The fix is pretty simple and just involves iterating over the `meinfo.keys()` instead of the whole `gidvec` since not all the data metadata is loaded in dry run.

## Scope
Just a simple fix.

## Testing
No new testing needed.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
