### PR TITLE
[BBPGLIB-1148] Add support for gap junctions in dry run

### DIFF
--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -9,6 +9,7 @@ from collections import defaultdict, Counter
 from itertools import chain
 from os import path as ospath
 from typing import List, Optional
+from libsonata._libsonata import SonataError
 
 from .core import NeurodamusCore as Nd
 from .core import ProgressBarRank0 as ProgressBar, MPI
@@ -775,7 +776,13 @@ class ConnectionManagerBase(object):
                 sample_len = len(sample)
                 if not sample_len:
                     continue
-                sample_counts = self._synapse_reader.get_counts(sample, group_by="syn_type_id")
+                try:
+                    sample_counts = self._synapse_reader.get_counts(sample, group_by="syn_type_id")
+                except SonataError as e:
+                    logging.warning("Error while getting synapse counts: %s", e)
+                    logging.warning("You might be using a non-compliant version of the edge file.")
+                    continue
+
                 logging.debug("Gids: %s... Types: %s", sample[:10], sample_counts)
                 logging.debug("Average syn/cell: %.2f", sum(sample_counts.values()) / sample_len)
                 sampled_gids_count += sample_len

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -9,7 +9,7 @@ from collections import defaultdict, Counter
 from itertools import chain
 from os import path as ospath
 from typing import List, Optional
-from libsonata._libsonata import SonataError
+from libsonata import SonataError
 
 from .core import NeurodamusCore as Nd
 from .core import ProgressBarRank0 as ProgressBar, MPI

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -777,12 +777,16 @@ class ConnectionManagerBase(object):
                 if not sample_len:
                     continue
                 try:
-                    sample_counts = self._synapse_reader.get_counts(sample, group_by="syn_type_id")
+                    if self.CONNECTIONS_TYPE == ConnectionTypes.Synaptic:
+                        sample_counts = self._synapse_reader.get_counts(
+                            sample, group_by="syn_type_id")
+                    else:
+                        sample_counts = self._synapse_reader.get_counts(sample)
+                        sample_counts = {self.CONNECTIONS_TYPE: sample_counts}
                 except SonataError as e:
                     logging.warning("Error while getting synapse counts: %s", e)
-                    logging.warning("You might be using a non-compliant version of the edge file.")
+                    logging.warning("Skipping range %d:%d", start, stop)
                     continue
-
                 logging.debug("Gids: %s... Types: %s", sample[:10], sample_counts)
                 logging.debug("Average syn/cell: %.2f", sum(sample_counts.values()) / sample_len)
                 sampled_gids_count += sample_len

--- a/neurodamus/io/synapse_reader.py
+++ b/neurodamus/io/synapse_reader.py
@@ -376,11 +376,15 @@ class SonataReader(SynapseReader):
 
         return conn_syn_params
 
-    def get_counts(self, raw_ids, group_by):
+    def get_counts(self, raw_ids, group_by=None):
         """
         Counts synapses and groups by the given field.
+        If called with group_by = None returns an int.
+        If called with any group_by it returns a dict.
         """
         edge_ids = self._population.afferent_edges(raw_ids - 1)
+        if group_by is None:
+            return edge_ids.flat_size
         data = self._population.get_attribute(group_by, edge_ids)
         values, counts = np.unique(data, return_counts=True)
         return dict(zip(values, counts))

--- a/neurodamus/neuromodulation_manager.py
+++ b/neurodamus/neuromodulation_manager.py
@@ -3,6 +3,7 @@ import logging
 from .connection_manager import SynapseRuleManager
 from .connection import Connection, NetConType, ReplayMode
 from .core.configuration import GlobalConfig, SimConfig
+from .io.sonata_config import ConnectionTypes
 from .io.synapse_reader import SynapseParameters, SonataReader
 from .utils.logging import log_all
 
@@ -121,6 +122,7 @@ class NeuroModulationSynapseReader(SonataReader):
 
 
 class NeuroModulationManager(SynapseRuleManager):
+    CONNECTIONS_TYPE = ConnectionTypes.NeuroModulation
     conn_factory = NeuroModulationConnection
     SynapseReader = NeuroModulationSynapseReader
 

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -17,6 +17,8 @@ import gzip
 from ..core import MPI, NeurodamusCore as Nd, run_only_rank0
 from .compat import Vector
 from collections import defaultdict
+from enum import Enum
+from ..io.sonata_config import ConnectionTypes
 
 import numpy as np
 
@@ -309,24 +311,43 @@ class DryRunStats:
         logging.info(" - Estimated synapse memory usage (MB):")
         from .logging import log_verbose
         inh_count = exc_count = 0
+        gap_count = other_count = 0
         log_verbose("+{:=^68}+".format(" Synapse Count "))
         log_verbose("| {:^40s} | {:^10s} | {:^10s} |".format("Synapse Type", "Family", "Count"))
         log_verbose("+{:-^68}+".format(""))
-        for syn_type, count in sorted(master_counter.items()):
+        numeric_items = [(syn_type, count)
+                         for syn_type, count in master_counter.items()
+                         if isinstance(syn_type, (int, np.integer))]
+        for syn_type, count in sorted(numeric_items):
             is_inh = syn_type < 100
-            syn_type_str = "INH" if is_inh else "EXC"
-            log_verbose("| {:40.0f} | {:<10s} | {:10.0f} |".format(syn_type, syn_type_str, count))
+            type_str = "INH" if is_inh else "EXC"
+            log_verbose("| {:40.0f} | {:<10s} | {:10.0f} |".format(syn_type, type_str, count))
             if is_inh:
                 inh_count += count
             else:
                 exc_count += count
+
+        string_items = [(syn_type, count)
+                        for syn_type, count in master_counter.items()
+                        if isinstance(syn_type, (Enum))]
+        for syn_type, count in string_items:
+            is_gap = syn_type == ConnectionTypes.GapJunction
+            type_str = "Gap" if is_gap else "Other"
+            log_verbose("| {:>40s} | {:<10s} | {:10.0f} |".format(str(syn_type), type_str, count))
+            if is_gap:
+                gap_count += count
+            else:
+                other_count += count
+
         log_verbose("+{:-^68}+".format(""))
 
         in_mem = SynapseMemoryUsage.get_memory_usage(inh_count, "ProbGABAAB") / 1024
         ex_mem = SynapseMemoryUsage.get_memory_usage(exc_count, "ProbAMPANMDA") / 1024
-        self.synapse_memory_total = in_mem + ex_mem
+        gap_mem = SynapseMemoryUsage.get_memory_usage(gap_count, "Gap") / 1024
+        self.synapse_memory_total = in_mem + ex_mem + gap_mem
         logging.info("   - Inhibitory: %s", pretty_printing_memory_mb(in_mem))
         logging.info("   - Excitatory: %s", pretty_printing_memory_mb(ex_mem))
+        logging.info("   - Gap: %s", pretty_printing_memory_mb(gap_mem))
         logging.info(" - TOTAL : %s", pretty_printing_memory_mb(self.synapse_memory_total))
 
     @run_only_rank0

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -315,6 +315,8 @@ class DryRunStats:
         log_verbose("+{:=^68}+".format(" Synapse Count "))
         log_verbose("| {:^40s} | {:^10s} | {:^10s} |".format("Synapse Type", "Family", "Count"))
         log_verbose("+{:-^68}+".format(""))
+
+        # Some synapse types are numeric, others are strings, so we need to handle both
         numeric_items = [(syn_type, count)
                          for syn_type, count in master_counter.items()
                          if isinstance(syn_type, (int, np.integer))]


### PR DESCRIPTION
## Context
This MR solves https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-1148

After investigation it seems that the `sonataconf-thalamus` circuit from `blueconfig` is including also gap junctions, that's why some of the connections were missing the `syn_type_id`.
Now the dry run can correctly treat gap junctions, count them and add to the synapse memory total. All the other types are also counted for future use.

## Scope
Made the `get_counts` function work also when no `group_by` is specified, in which case it will return an int.
Added more branch and checks to take into account non-chemical connections.

## Testing
No further testing needed.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
