### PR TITLE
[BBPBGLIB-1153] Allow disabling reports from SONATA config

### DIFF
--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -824,7 +824,7 @@ class Node:
         """
         log_stage("Reports Enabling")
         n_errors = 0
-        reports_conf = SimConfig.reports
+        reports_conf = {name: conf for name, conf in SimConfig.reports.items() if conf["Enabled"]}
         self._report_list = []
 
         # Create a map of offsets so that it can be used even on coreneuron save-restore

--- a/tests/integration-e2e/test_reports.py
+++ b/tests/integration-e2e/test_reports.py
@@ -9,10 +9,10 @@ from tempfile import NamedTemporaryFile
 SIM_DIR = Path(__file__).parent.parent.absolute() / "simulations" / "v5_sonata"
 
 @pytest.fixture
-def sonata_config_synapse_report(sonata_config):
+def sonata_config_new_report(sonata_config):
 
     extra_config = {"reports": {
-        "synapse_report": {
+        "new_report": {
             "type": "compartment",
             "cells": "Mosaic",
             "variable_name": "v",
@@ -28,23 +28,23 @@ def sonata_config_synapse_report(sonata_config):
     return sonata_config
 
 @pytest.fixture
-def sonata_config_file_err(sonata_config_synapse_report):
+def sonata_config_file_err(sonata_config_new_report):
 
-    sonata_config_synapse_report["reports"]["synapse_report"]["variable_name"] = "wrong"
+    sonata_config_new_report["reports"]["new_report"]["variable_name"] = "wrong"
 
     with NamedTemporaryFile("w", suffix='.json', delete=False) as config_file:
-        json.dump(sonata_config_synapse_report, config_file)
+        json.dump(sonata_config_new_report, config_file)
 
     yield config_file
     os.unlink(config_file.name)
 
 @pytest.fixture
-def sonata_config_file_disabled_report(sonata_config_synapse_report):
+def sonata_config_file_disabled_report(sonata_config_new_report):
 
-    sonata_config_synapse_report["reports"]["synapse_report"]["enabled"] = False
+    sonata_config_new_report["reports"]["new_report"]["enabled"] = False
 
     with NamedTemporaryFile("w", suffix='.json', delete=False) as config_file:
-        json.dump(sonata_config_synapse_report, config_file)
+        json.dump(sonata_config_new_report, config_file)
 
     yield config_file
     os.unlink(config_file.name)

--- a/tests/integration-e2e/test_reports.py
+++ b/tests/integration-e2e/test_reports.py
@@ -8,6 +8,7 @@ from tempfile import NamedTemporaryFile
 
 SIM_DIR = Path(__file__).parent.parent.absolute() / "simulations" / "v5_sonata"
 
+
 @pytest.fixture
 def sonata_config_new_report(sonata_config):
 
@@ -27,6 +28,7 @@ def sonata_config_new_report(sonata_config):
 
     return sonata_config
 
+
 @pytest.fixture
 def sonata_config_file_err(sonata_config_new_report):
 
@@ -37,6 +39,7 @@ def sonata_config_file_err(sonata_config_new_report):
 
     yield config_file
     os.unlink(config_file.name)
+
 
 @pytest.fixture
 def sonata_config_file_disabled_report(sonata_config_new_report):
@@ -49,6 +52,7 @@ def sonata_config_file_disabled_report(sonata_config_new_report):
     yield config_file
     os.unlink(config_file.name)
 
+
 @pytest.mark.slow
 def test_report_config_error(sonata_config_file_err):
     with pytest.raises(Exception):
@@ -57,6 +61,7 @@ def test_report_config_error(sonata_config_file_err):
         n.create_cells()
         n.enable_reports()
 
+
 @pytest.mark.slow
 def test_report_disabled(sonata_config_file_disabled_report):
     n = Node(str(sonata_config_file_disabled_report.name))
@@ -64,6 +69,7 @@ def test_report_disabled(sonata_config_file_disabled_report):
     n.create_cells()
     n.enable_reports()
     assert len(n.reports) == 0
+
 
 def _read_sonata_report(report_file):
     import libsonata


### PR DESCRIPTION
## Note
Identical to PR #156, re-opening after being added to the Github organization

## Context
This PR solves
https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-1153.

According to the SONATA specification, reports can be disabled with an optional enabled parameter in the config file. This option was already parsed, but not used to disable the reports.

## Scope
A small change to the `enable_reports` method of the `Node` class, filtering the reports based on the `enabled` flag.

## Testing
An integration test in `tests/integration-e2e/test_reports.py`, reusing part of the existing fixture there and reading the flag from a SONATA config file.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
