### PR TITLE
Fix dead link from CONTRIBUTING.md to README.rst

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ the main (upstream) repository:
 # Development Environment
 
 Please make sure to install the project requirements,
-see the [dependencies](./README.md#dependencies) section in top README.
+see the [dependencies](./README.rst#prerequisites) section in top README.
 
 This section applies to both Python versions 2 and 3.
 


### PR DESCRIPTION
## Note
Identical to PR #157, re-opening after being added to the Github organization.

## Context
A small fix of a link in CONTRIBUTING.md that was still pointing to a markdown version of the README.

## Review
* [x] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
