### PR TITLE
[BBPBGLIB-1154] Add information about CORENEURONLIB in the Docker README

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -95,11 +95,15 @@ jobs:
         export PYTHONPATH=$(pwd)/nrn/build/lib/python:$PYTHONPATH
         cp neurodamus/data/hoc/* tests/share/hoc/
         export HOC_LIBRARY_PATH=$(pwd)/tests/share/hoc
+        export CORENEURONLIB = $(pwd)/x86_64/libcorenrnmech.so
+        export PATH=$(pwd)/x86_64:$PATH
+        which special
         # launch simulation with NEURON
-        mpirun -np 2 ./x86_64/special -mpi -python neurodamus/data/init.py --configFile=tests/simulations/usecase3/simulation_sonata.json
-        ls tests/simulations/usecase3/reporting/*.h5
+        cd tests/simulations/usecase3/
+        mpirun -np 2 special -mpi -python neurodamus/data/init.py --configFile=simulation_sonata.json
+        ls reporting/*.h5
         # launch simulation with CORENEURON
-        mpirun -np 2 ./x86_64/special -mpi -python neurodamus/data/init.py --configFile=tests/simulations/usecase3/simulation_sonata_coreneuron.json
+        mpirun -np 2 special -mpi -python neurodamus/data/init.py --configFile=simulation_sonata_coreneuron.json
         ls tests/simulations/usecase3/reporting_coreneuron/*.h5
 
     # - name: live debug session, comment out

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -95,7 +95,7 @@ jobs:
         export PYTHONPATH=$(pwd)/nrn/build/lib/python:$PYTHONPATH
         cp neurodamus/data/hoc/* tests/share/hoc/
         export HOC_LIBRARY_PATH=$(pwd)/tests/share/hoc
-        export CORENEURONLIB = $(pwd)/x86_64/libcorenrnmech.so
+        export CORENEURONLIB=$(pwd)/x86_64/libcorenrnmech.so
         export PATH=$(pwd)/x86_64:$PATH
         which special
         # launch simulation with NEURON

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -89,9 +89,6 @@ jobs:
         cp -r mod tests/share/
         cp neurodamus/data/mod/*.mod tests/share/mod/
         ./docker/build_neurodamus.sh tests/share/mod
-        export CORENEURONLIB=$(pwd)/x86_64/libcorenrnmech.so
-        export PATH=$(pwd)/x86_64:$PATH
-        which special
 
     - name: Example run
       run: |
@@ -99,6 +96,10 @@ jobs:
         cp neurodamus/data/hoc/* tests/share/hoc/
         export HOC_LIBRARY_PATH=$(pwd)/tests/share/hoc
         export NEURODAMUS_PYTHON=$(pwd)/neurodamus/data
+        export CORENEURONLIB=$(pwd)/x86_64/libcorenrnmech.so
+        export PATH=$(pwd)/x86_64:$PATH
+        which special
+
         # launch simulation with NEURON
         cd tests/simulations/usecase3/
         mpirun -np 2 special -mpi -python $NEURODAMUS_PYTHON/init.py --configFile=simulation_sonata.json

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -106,7 +106,7 @@ jobs:
         ls reporting/*.h5
         # launch simulation with CORENEURON
         mpirun -np 2 special -mpi -python $NEURODAMUS_PYTHON/init.py --configFile=simulation_sonata_coreneuron.json
-        ls tests/simulations/usecase3/reporting_coreneuron/*.h5
+        ls reporting_coreneuron/*.h5
 
     # - name: live debug session, comment out
     #   if: failure()

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -89,21 +89,22 @@ jobs:
         cp -r mod tests/share/
         cp neurodamus/data/mod/*.mod tests/share/mod/
         ./docker/build_neurodamus.sh tests/share/mod
+        export CORENEURONLIB=$(pwd)/x86_64/libcorenrnmech.so
+        export PATH=$(pwd)/x86_64:$PATH
+        which special
 
     - name: Example run
       run: |
         export PYTHONPATH=$(pwd)/nrn/build/lib/python:$PYTHONPATH
         cp neurodamus/data/hoc/* tests/share/hoc/
         export HOC_LIBRARY_PATH=$(pwd)/tests/share/hoc
-        export CORENEURONLIB=$(pwd)/x86_64/libcorenrnmech.so
-        export PATH=$(pwd)/x86_64:$PATH
-        which special
+        export NEURODAMUS_PYTHON=$(pwd)/neurodamus/data
         # launch simulation with NEURON
         cd tests/simulations/usecase3/
-        mpirun -np 2 special -mpi -python neurodamus/data/init.py --configFile=simulation_sonata.json
+        mpirun -np 2 special -mpi -python $NEURODAMUS_PYTHON/init.py --configFile=simulation_sonata.json
         ls reporting/*.h5
         # launch simulation with CORENEURON
-        mpirun -np 2 special -mpi -python neurodamus/data/init.py --configFile=simulation_sonata_coreneuron.json
+        mpirun -np 2 special -mpi -python $NEURODAMUS_PYTHON/init.py --configFile=simulation_sonata_coreneuron.json
         ls tests/simulations/usecase3/reporting_coreneuron/*.h5
 
     # - name: live debug session, comment out

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,7 +30,7 @@ bluebrain/neurodamus                  latest    4784d73155e7   11 hours ago   4.
 ## Docker containier
 With the docker image, you can start a neurodamus container with an interative Bash shell and meanwhile mount your local folder which contains your mod files and the circuit data.
 ```
-docker run --rm -it -v <folder_mods_circuit>:/mnt/mydata bluebrain/neurodamus
+docker run --rm -it -v <full path of your folder_mods_circuit>:/mnt/mydata bluebrain/neurodamus
 ```
 In the Bash shell, first build your mods:
 ```
@@ -42,6 +42,11 @@ build_neurodamus.sh <your_mod_dir>/
 If you have additional hoc files, add the location to `$HOC_LIBRARY_PATH`
 ```
 export HOC_LIBRARY_PATH=/mnt/mydata/<your_hoc_dir>:$HOC_LIBRARY_PATH
+```
+
+If you would like to run with CORENEURON, set the environment variable `CORENEURONLIB` to your built coreneuron library, e.g.
+```
+export CORENEURONLIB=/mnt/mydata/x86_64/libcorenrnmech.so
 ```
 
 Then you are ready to start the simulation.

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,7 +44,7 @@ If you have additional hoc files, add the location to `$HOC_LIBRARY_PATH`
 export HOC_LIBRARY_PATH=/mnt/mydata/<your_hoc_dir>:$HOC_LIBRARY_PATH
 ```
 
-If you would like to run with CORENEURON, set the environment variable `CORENEURONLIB` to your built coreneuron library, e.g.
+If you would like to run with CoreNEURON, set the environment variable `CORENEURONLIB` to the built CoreNEURON library, e.g.
 ```
 export CORENEURONLIB=/mnt/mydata/x86_64/libcorenrnmech.so
 ```

--- a/tests/share/hoc/AMPANMDAHelper.hoc
+++ b/tests/share/hoc/AMPANMDAHelper.hoc
@@ -57,19 +57,8 @@ proc init() { local tgid, x, synapseID, baseSeed, seed2, spopid, tpopid  localob
 
     rngInfo = new RNGSettings()
 
-    if( rngInfo.getRNGMode() == rngInfo.RANDOM123 ) {
-        seed2 = spopid*65536 + tpopid + rngInfo.getSynapseSeed() + 300
-        synapse.setRNG( tgid+250, synapseID+100, seed2 )
-    } else {
-        rng = new Random()
-        if( rngInfo.getRNGMode() == rngInfo.COMPATIBILITY ) {
-            rng.MCellRan4( synapseID*100000+100, tgid+250+baseSeed )
-        } else if( rngInfo.getRNGMode() == rngInfo.UPMCELLRAN4 ) {
-            rng.MCellRan4( synapseID*1000+100, spopid*16777216+tgid+250+baseSeed+rngInfo.getSynapseSeed() )
-        }
-        rng.uniform(0,1)
-        synapse.setRNG( rng )
-    }
+    seed2 = spopid*65536 + tpopid + rngInfo.getSynapseSeed() + 300
+    synapse.setRNG( tgid+250, synapseID+100, seed2 )
     synapse.synapseID = synapseID
 }
 

--- a/tests/share/hoc/GABAABHelper.hoc
+++ b/tests/share/hoc/GABAABHelper.hoc
@@ -50,14 +50,8 @@ proc init() { local tgid, x, synapseID, baseSeed, seed2, spopid, tpopid  localob
 
     if ( strcmp( randomize_Gaba_risetime, "True") == 0 ) {
         rng = new Random()
-        if( rngInfo.getRNGMode() == rngInfo.COMPATIBILITY ) {
-            rng.MCellRan4( synapseID*100000+100, tgid+250+baseSeed )
-        } else if( rngInfo.getRNGMode() == rngInfo.UPMCELLRAN4 ) {
-            rng.MCellRan4( synapseID*1000+100, spopid*16777216+tgid+250+baseSeed+rngInfo.getSynapseSeed() )
-        } else if( rngInfo.getRNGMode() == rngInfo.RANDOM123 ) {
-            seed2 = spopid*65536 + tpopid + rngInfo.getSynapseSeed() + 450
-            rng.Random123( tgid+250, synapseID+100, seed2 )
-        }
+        seed2 = spopid*65536 + tpopid + rngInfo.getSynapseSeed() + 450
+        rng.Random123( tgid+250, synapseID+100, seed2 )
         rng.lognormal(0.2, 0.1)
         synapse.tau_r_GABAA = rng.repick()
     }
@@ -78,19 +72,8 @@ proc init() { local tgid, x, synapseID, baseSeed, seed2, spopid, tpopid  localob
         quit()
     }
 
-    if( rngInfo.getRNGMode() == rngInfo.RANDOM123 ) {
-        seed2 = spopid*65536 + tpopid + rngInfo.getSynapseSeed() + 300
-        synapse.setRNG( tgid+250, synapseID+100, seed2 )
-    } else {
-        rng = new Random()
-        if( rngInfo.getRNGMode() == rngInfo.COMPATIBILITY ) {
-            rng.MCellRan4( synapseID*100000+100, tgid+250+baseSeed )
-        } else if( rngInfo.getRNGMode() == rngInfo.UPMCELLRAN4 ) {
-            rng.MCellRan4( synapseID*1000+100, spopid*16777216+tgid+250+baseSeed+rngInfo.getSynapseSeed() )
-        }
-        rng.uniform(0,1)
-        synapse.setRNG( rng )
-    }
+    seed2 = spopid*65536 + tpopid + rngInfo.getSynapseSeed() + 300
+    synapse.setRNG( tgid+250, synapseID+100, seed2 )
     synapse.synapseID = synapseID
 }
 


### PR DESCRIPTION
## Context
For neurodamus standalone build, the environment variable `CORENEURONLIB` should point to the coreneuron shared library in order to run CoreNEURON simulation. Without this variable, CoreNEURON may not load all the mechanism files correctly which has been seen in the docker container. 

## Scope
Specify such information in the Docker README. Also add it in the GH workflow.

## Testing
Current GH actions workflow.

## Review
* [x] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
