### PR TITLE
Tests with subprocess should capture streams

### DIFF
--- a/tests/integration-e2e/test_cli_opts.py
+++ b/tests/integration-e2e/test_cli_opts.py
@@ -39,9 +39,9 @@ def test_save_restore_cli():
             # Save-Restore raises exception when using NEURON
             if simulator == "NEURON":
                 with pytest.raises(subprocess.CalledProcessError):
-                    subprocess.run(command, check=True)
+                    subprocess.run(command, check=True, capture_output=True)
             else:
-                subprocess.run(command, check=True)
+                subprocess.run(command, check=True, capture_output=True)
 
 
 def test_cli_prcellgid():
@@ -70,6 +70,7 @@ def test_cli_disable_reports():
     subprocess.run(
         ["neurodamus", CONFIG_FILE_MINI, "--disable-reports"],
         check=True,
+        capture_output=True,
         cwd=test_folder_path
     )
     # Spikes are present even if we disable reports
@@ -81,6 +82,7 @@ def test_cli_disable_reports():
     subprocess.run(
         ["neurodamus", CONFIG_FILE_MINI],
         check=True,
+        capture_output=True,
         cwd=test_folder_path
     )
     assert (test_folder_path / sim_config_data["output"]["output_dir"] / "out.h5").is_file()

--- a/tests/integration-e2e/test_plugin.py
+++ b/tests/integration-e2e/test_plugin.py
@@ -144,4 +144,5 @@ def test_run_acell_circuit():
         ["bash", "tests/test_simulation.bash", str(simdir), "BlueConfig", ""],
         env=env,
         check=True,
+        capture_output=True,
     )


### PR DESCRIPTION
## Context

Not all tests using subprocess would capture std streams. This means pytest could not handle their output properly. 
Fixes #51

## Scope
Make all tests using subprocess capture std streams.

## Testing
CI

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
