### PR TITLE
[BBPBGLIB-1158] Add empirical mechanism to estimate simulation memory usage

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -389,7 +389,7 @@ process before any of the actual instantiation is done. This value, since it's a
 part in the execution, is then multiplied by the number of ranks used in the execution.
 
 On top of this we also need to consider the memory usage of the simulation itself. Unfortunately
-at the moment there are no easy ways to estimate this value, so we have opted for a simple euristic
+at the moment there are no easy ways to estimate this value, so we have opted for a simple heuristic
 approach. We assume that the memory usage of the simulation is proportional to the memory usage of
 the cells and synapses. From tests on a wide variety of circuits we've seen that the simulation memory 
 usage is typically between 1.5 and 2.5 times the memory usage of the cells and synapses. We've opted for

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -320,8 +320,8 @@ Dry Run
 -------
 
 A dry run mode was introduced to help users in understanding how many nodes and tasks are
-necessary to run a specific circuit. In the future this mode will also be used to improve
-load balancing.
+necessary to run a specific circuit. This mode can also be used to improve load balancing,
+as it generates an `allocation.pkl.gz` file which can be used to load balance the simulation.
 
 By running a dry run, using the `--dry-run` flag, the user will NOT run an actual simulation but
 will get a summary of the estimated memory used for cells and synapses, including also the overhead
@@ -387,6 +387,16 @@ Apart from both cells and synapses, we also need to take into account the memory
 itself, e.g. data structures, loaded libraries and so on. This is done by measuring the RSS of the neurodamus
 process before any of the actual instantiation is done. This value, since it's averaged over all ranks that take
 part in the execution, is then multiplied by the number of ranks used in the execution.
+
+On top of this we also need to consider the memory usage of the simulation itself. Unfortunately
+at the moment there are no easy ways to estimate this value, so we have opted for a simple euristic
+approach. We assume that the memory usage of the simulation is proportional to the memory usage of
+the cells and synapses. From tests on a wide variety of circuits we've seen that the simulation memory 
+usage is typically between 1.5 and 2.5 times the memory usage of the cells and synapses. We've opted for
+the more conservative value of 2.5 times the memory usage of the cells and synapses.
+The simulation estimate is not considered for the load balancing part of the dry run since we assume that
+it's proportional to the memory usage of the cells and synapses and it's just used for the suggestions
+of nodes to use in the simulation and the relative target ranks (more on this later).
 
 The final result is then printed to the user in a human readable format together with an estimate
 of the number of nodes needed to run the simulation on the same machine used to run the dry run.

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -22,6 +22,11 @@ from ..io.sonata_config import ConnectionTypes
 
 import numpy as np
 
+# The factor to multiply the cell + synapses memory usage by to get the simulation memory estimate.
+# This is an heuristic estimate based on tests on multiple circuits.
+# More info in docs/architecture.rst.
+SIM_ESTIMATE_FACTOR = 2.5
+
 
 def trim_memory():
     """
@@ -256,7 +261,6 @@ class DryRunStats:
         self.metype_counts = Counter()
         self.synapse_counts = Counter()
         self.suggested_nodes = 0
-        self.sim_estimate_factor = 2.5
         _, _, self.base_memory, _ = get_task_level_mem_usage()
 
     @run_only_rank0
@@ -363,7 +367,7 @@ class DryRunStats:
         logging.info("| {:<40s} | {:12.1f} |".format("Cells", self.cell_memory_total))
         logging.info("| {:<40s} | {:12.1f} |".format("Synapses", self.synapse_memory_total))
         self.simulation_estimate = (self.cell_memory_total
-                                    + self.synapse_memory_total) * self.sim_estimate_factor
+                                    + self.synapse_memory_total) * SIM_ESTIMATE_FACTOR
         logging.info("| {:<40s} | {:12.1f} |".format("Simulation", self.simulation_estimate))
         logging.info("+{:-^57}+".format(""))
         grand_total = (full_overhead
@@ -410,7 +414,7 @@ class DryRunStats:
         while (prev_est_nodes is None or est_nodes != prev_est_nodes) and iter_count < max_iter:
             prev_est_nodes = est_nodes
             simulation_estimate = (self.cell_memory_total +
-                                   self.synapse_memory_total) * self.sim_estimate_factor
+                                   self.synapse_memory_total) * SIM_ESTIMATE_FACTOR
             mem_usage_per_node = (full_overhead
                                   + self.cell_memory_total
                                   + self.synapse_memory_total

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -361,8 +361,13 @@ class DryRunStats:
         logging.info("| {:<40s} | {:12.1f} |".format(f"Overhead (ranks={MPI.size})", full_overhead))
         logging.info("| {:<40s} | {:12.1f} |".format("Cells", self.cell_memory_total))
         logging.info("| {:<40s} | {:12.1f} |".format("Synapses", self.synapse_memory_total))
+        self.simulation_estimate = (self.cell_memory_total + self.synapse_memory_total) * 2.5
+        logging.info("| {:<40s} | {:12.1f} |".format("Simulation", self.simulation_estimate))
         logging.info("+{:-^57}+".format(""))
-        grand_total = full_overhead + self.cell_memory_total + self.synapse_memory_total
+        grand_total = (full_overhead
+                       + self.cell_memory_total
+                       + self.synapse_memory_total
+                       + self.simulation_estimate)
         grand_total = pretty_printing_memory_mb(grand_total)
         logging.info("| {:<40s} | {:>12s} |".format("GRAND TOTAL", grand_total))
         logging.info("+{:-^57}+".format(""))
@@ -402,7 +407,11 @@ class DryRunStats:
 
         while (prev_est_nodes is None or est_nodes != prev_est_nodes) and iter_count < max_iter:
             prev_est_nodes = est_nodes
-            mem_usage_per_node = full_overhead + self.cell_memory_total + self.synapse_memory_total
+            simulation_estimate = (self.cell_memory_total + self.synapse_memory_total) * 2.5
+            mem_usage_per_node = (full_overhead
+                                  + self.cell_memory_total
+                                  + self.synapse_memory_total
+                                  + simulation_estimate)
             mem_usage_with_margin = mem_usage_per_node * (1 + margin)
             est_nodes = math.ceil(mem_usage_with_margin / DryRunStats.total_memory_available())
             full_overhead = self.base_memory * ranks_per_node * est_nodes

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -256,6 +256,7 @@ class DryRunStats:
         self.metype_counts = Counter()
         self.synapse_counts = Counter()
         self.suggested_nodes = 0
+        self.sim_estimate_factor = 2.5
         _, _, self.base_memory, _ = get_task_level_mem_usage()
 
     @run_only_rank0
@@ -361,7 +362,8 @@ class DryRunStats:
         logging.info("| {:<40s} | {:12.1f} |".format(f"Overhead (ranks={MPI.size})", full_overhead))
         logging.info("| {:<40s} | {:12.1f} |".format("Cells", self.cell_memory_total))
         logging.info("| {:<40s} | {:12.1f} |".format("Synapses", self.synapse_memory_total))
-        self.simulation_estimate = (self.cell_memory_total + self.synapse_memory_total) * 2.5
+        self.simulation_estimate = (self.cell_memory_total
+                                    + self.synapse_memory_total) * self.sim_estimate_factor
         logging.info("| {:<40s} | {:12.1f} |".format("Simulation", self.simulation_estimate))
         logging.info("+{:-^57}+".format(""))
         grand_total = (full_overhead
@@ -407,7 +409,8 @@ class DryRunStats:
 
         while (prev_est_nodes is None or est_nodes != prev_est_nodes) and iter_count < max_iter:
             prev_est_nodes = est_nodes
-            simulation_estimate = (self.cell_memory_total + self.synapse_memory_total) * 2.5
+            simulation_estimate = (self.cell_memory_total +
+                                   self.synapse_memory_total) * self.sim_estimate_factor
             mem_usage_per_node = (full_overhead
                                   + self.cell_memory_total
                                   + self.synapse_memory_total

--- a/tests/integration-e2e/test_dry_run_workflow.py
+++ b/tests/integration-e2e/test_dry_run_workflow.py
@@ -24,7 +24,7 @@ def test_dry_run_workflow(USECASE3):
 
     assert 20.0 <= nd._dry_run_stats.cell_memory_total <= 30.0
     assert 0.0 <= nd._dry_run_stats.synapse_memory_total <= 1.0
-    assert 80.0 <= nd._dry_run_stats.base_memory <= 120.0
+    assert 75.0 <= nd._dry_run_stats.base_memory <= 120.0
     expected_items = {
         'L4_PC-dSTUT': 2,
         'L4_MC-dSTUT': 1,


### PR DESCRIPTION
## Context
Add an estimate for the simulation memory usage. The estimate is simply calculated considering 2.5 times the total amount of memory estimated for cell + synapses. 
This factor is based on tests that we performed on a variety of circuit that seem to suggest that the ratio between the instantiation and the simulation tops at 2.5 times.

For more information see: https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-1158

## Scope
Just a simple add to already existing functions.

## Testing
The modification will be tested during the already implemented integration tests for the dry run workflow.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
