### PR TITLE
Cache dependent packages in GH actions workflow

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -98,7 +98,7 @@ jobs:
         key: build-neuron-${{ env.NEURON_BRANCH }}-${{ env.NEURON_COMMIT_ID }}
 
     - name: Install NEURON
-      # if: steps.cache-neuron.outputs.cache-hit != 'true'
+      if: steps.cache-neuron.outputs.cache-hit != 'true'
       run: |
         . ./venv/bin/activate
         sudo apt-get install flex libfl-dev bison ninja-build

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   NEURON_COMMIT_ID: '13654b3'
+  LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
 
 jobs:
   simulation:
@@ -47,9 +48,19 @@ jobs:
       run: |
         CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata
 
+    - name: Cache libsonatareport
+      id: cache-libsonatareport
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-libsonatareport
+      with:
+        path: ${{ github.workspace }}/libsonatareport
+        key: build-libsonatareport-${{ env.LIBSONATA_REPORT_TAG }}
+
     - name: Install libsonatareport
+      if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
-        git clone --branch="${LIBSONATA_REPORT_BRANCH:-master}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
+        git clone --branch="${{ env.LIBSONATA_REPORT_TAG}}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON ..
@@ -63,7 +74,7 @@ jobs:
         cache-name: cache-neuron
       with:
         path: ${{ github.workspace }}/nrn
-        key: build-neuron-${{ env.NEURON_COMMIT_ID}}
+        key: build-neuron-${{ env.NEURON_COMMIT_ID }}
 
     - name: Install NEURON
       if: steps.cache-neuron.outputs.cache-hit != 'true'

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -14,12 +14,11 @@ on:
         default: 'master'
       LIBSONATA_REPORT_BRANCH:
         description: 'libsonatareport branch to use'
-        required: true
-        default: '1.2.3'
+        required: false
 
 env:
   NEURON_COMMIT_ID: '13654b3'
-  # LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
+  LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
 
 jobs:
   simulation:
@@ -57,13 +56,12 @@ jobs:
         cache-name: cache-libsonatareport
       with:
         path: ${{ github.workspace }}/libsonatareport
-        key: build-libsonatareport-${{ github.event.inputs.LIBSONATA_REPORT_BRANCH }}
+        key: build-libsonatareport-${{ env.LIBSONATA_REPORT_TAG }}
 
     - name: Install libsonatareport
       if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
-        echo "LIBSONATA_REPORT_BRANCH" ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH }}
-        git clone --branch="${{ github.event.inputs.LIBSONATA_REPORT_BRANCH }}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
+        git clone --branch="${{ env.LIBSONATA_REPORT_TAG}}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON ..

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -10,7 +10,8 @@ on:
     inputs:
       NEURON_BRANCH:
         description: 'NEURON branch to use'
-        required: false
+        required: true
+        default: 'master'
       LIBSONATA_REPORT_BRANCH:
         description: 'libsonatareport branch to use'
         required: false
@@ -69,6 +70,7 @@ jobs:
 
     - name: Cache NEURON
       id: cache-neuron
+      if: ${{ inputs.NEURON_BRANCH }} == 'master'
       uses: actions/cache@v3
       env:
         cache-name: cache-neuron
@@ -83,8 +85,11 @@ jobs:
         pip install -U pip setuptools
         pip install "cython<3" pytest sympy
         export SONATAREPORT_DIR=$(pwd)/libsonatareport/build/install
-        git clone --branch="${NEURON_BRANCH:-master}" https://github.com/neuronsimulator/nrn.git --depth=1
+        git clone --branch=${{ inputs.NEURON_BRANCH }} https://github.com/neuronsimulator/nrn.git
         cd nrn
+        if [[ ${{ inputs.NEURON_BRANCH }} == 'master' ]]; then
+          git checkout ${{ env.NEURON_COMMIT_ID }}
+        fi
         mkdir build && cd build
         cmake -G Ninja -DPYTHON_EXECUTABLE=$(which python) -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_INTERVIEWS=OFF \
           -DNRN_ENABLE_CORENEURON=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCORENRN_ENABLE_REPORTING=ON -DCMAKE_PREFIX_PATH=$SONATAREPORT_DIR ..

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -77,7 +77,7 @@ jobs:
       env:
         cache-name: cache-libsonatareport
       with:
-        path: ${{ github.workspace }}/libsonatareport
+        path: libsonatareport
         key: build-libsonatareport-${{ env.LIBSONATA_REPORT_BRANCH }}
 
     - name: Install libsonatareport
@@ -102,15 +102,15 @@ jobs:
     - name: Install NEURON
       if: steps.cache-neuron.outputs.cache-hit != 'true'
       run: |
-        sudo apt-get install flex libfl-dev bison ninja-build
-        . ./venv/bin/activate
-        pip install "cython<3" pytest sympy
         export SONATAREPORT_DIR=$(pwd)/libsonatareport/build/install
         git clone --branch=${{ env.NEURON_BRANCH }} https://github.com/neuronsimulator/nrn.git
-        cd nrn
         if [[ ${{ env.NEURON_BRANCH }} == 'master' ]]; then
           git checkout ${{ env.NEURON_COMMIT_ID }}
         fi
+        sudo apt-get install flex libfl-dev bison ninja-build
+        . ./venv/bin/activate
+        python -m pip install --upgrade pip -r nrn/nrn_requirements.txt
+        cd nrn
         mkdir build && cd build
         cmake -G Ninja -DPYTHON_EXECUTABLE=$(which python) -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_INTERVIEWS=OFF \
           -DNRN_ENABLE_CORENEURON=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCORENRN_ENABLE_REPORTING=ON -DCMAKE_PREFIX_PATH=$SONATAREPORT_DIR ..

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -15,6 +15,9 @@ on:
         description: 'libsonatareport branch to use'
         required: false
 
+env:
+  NEURON_COMMIT_ID: '13654b3'
+
 jobs:
   simulation:
     runs-on: ubuntu-22.04
@@ -53,7 +56,17 @@ jobs:
         cmake --build . --parallel
         cmake --build . --target install
 
+    - name: Cache NEURON
+      id: cache-neuron
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-neuron
+      with:
+        path: ${{ github.workspace }}/nrn
+        key: build-neuron-${{ env.NEURON_COMMIT_ID}}
+
     - name: Install NEURON
+      if: steps.cache-neuron.outputs.cache-hit != 'true'
       run: |
         sudo apt-get install flex libfl-dev bison ninja-build
         pip install -U pip setuptools

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -45,30 +45,31 @@ jobs:
         LIBSONATA_REPORT_BRANCH=$(echo $COMMIT_MESSAGE | grep -Po 'LIBSONATA_REPORT_BRANCH=\K[0-9a-zA-Z/_.\-]*' || true)
         if [[ ! -z $LIBSONATA_REPORT_BRANCH ]]; then echo "LIBSONATA_REPORT_BRANCH=$LIBSONATA_REPORT_BRANCH" >> $GITHUB_ENV; fi
 
-    - name: Cache libsonata
-      id: cache-libsonata
+    - name: Cache python virtual env
+      id: cache-venv
       uses: actions/cache@v3
       env:
-        cache-name: cache-libsonata
+        cache-name: cache-venv
       with:
         path: venv
-        key: build-${{ env.LIBSONATA_BRANCH }}
+        key: build-libsonata-${{ env.LIBSONATA_BRANCH }} # todo: add python version
 
     - name: Install hdf5-mpich
       run: |
         sudo apt-get update
         sudo apt-get install mpich libmpich-dev libhdf5-mpich-dev hdf5-tools
 
-    # - name: Setup python virtual env
-    #   run: |
-    #     python -m venv venv
-
-    - name: Install libsonata
-      if: steps.cache-libsonata.outputs.cache-hit != 'true'
+    - name: Setup python virtual env
       run: |
         python -m venv venv
         . ./venv/bin/activate
-        CC=mpicc CXX=mpic++ python -m pip install git+https://github.com/BlueBrain/libsonata@${{ env.LIBSONATA_BRANCH }}
+        pip install -U pip setuptools
+
+    - name: Install libsonata
+      if: steps.cache-venv.outputs.cache-hit != 'true'
+      run: |
+        . ./venv/bin/activate
+        CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata@${{ env.LIBSONATA_BRANCH }}
 
     - name: Cache libsonatareport
       id: cache-libsonatareport
@@ -95,15 +96,14 @@ jobs:
       env:
         cache-name: cache-neuron
       with:
-        path: ${{ github.workspace }}/nrn
+        path: nrn
         key: build-neuron-${{ env.NEURON_BRANCH }}-${{ env.NEURON_COMMIT_ID }}
 
     - name: Install NEURON
       if: steps.cache-neuron.outputs.cache-hit != 'true'
       run: |
-        . ./venv/bin/activate
         sudo apt-get install flex libfl-dev bison ninja-build
-        pip install -U pip setuptools
+        . ./venv/bin/activate
         pip install "cython<3" pytest sympy
         export SONATAREPORT_DIR=$(pwd)/libsonatareport/build/install
         git clone --branch=${{ env.NEURON_BRANCH }} https://github.com/neuronsimulator/nrn.git
@@ -117,12 +117,16 @@ jobs:
         cmake --build . --parallel
         cmake --build . --target install
 
+    - name: Build mpi4Py
+      if: steps.cache-venv.outputs.cache-hit != 'true'
+      run: |
+        . ./venv/bin/activate
+        pip install mpi4py
+
     - name: Build h5py with the local hdf5
       run: |
         . ./venv/bin/activate
-        pip install -U pip setuptools
         pip install cython numpy wheel pkgconfig
-        MPICC="mpicc -shared" pip install --no-cache-dir --no-binary=mpi4py mpi4py
         CC="mpicc" HDF5_MPI="ON" HDF5_INCLUDEDIR=/usr/include/hdf5/mpich HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich \
           pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
 

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -45,6 +45,15 @@ jobs:
         LIBSONATA_REPORT_BRANCH=$(echo $COMMIT_MESSAGE | grep -Po 'LIBSONATA_REPORT_BRANCH=\K[0-9a-zA-Z/_.\-]*' || true)
         if [[ ! -z $LIBSONATA_REPORT_BRANCH ]]; then echo "LIBSONATA_REPORT_BRANCH=$LIBSONATA_REPORT_BRANCH" >> $GITHUB_ENV; fi
 
+    - name: Cache libsonata
+      id: cache-libsonata
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-libsonata
+      with:
+        path: venv
+        key: build-${{ env.LIBSONATA_BRANCH }}
+
     - name: Install hdf5-mpich
       run: |
         sudo apt-get update
@@ -53,15 +62,6 @@ jobs:
     - name: Setup python virtual env
       run: |
         python -m venv venv
-
-    - name: Cache libsonata
-      id: cache-libsonata
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-libsonata
-      with:
-        path: venv
-        key: build-libsonata-${{ env.LIBSONATA_BRANCH }}
 
     - name: Install libsonata
       if: steps.cache-libsonata.outputs.cache-hit != 'true'
@@ -160,6 +160,6 @@ jobs:
         mpirun -np 2 special -mpi -python $NEURODAMUS_PYTHON/init.py --configFile=simulation_sonata_coreneuron.json
         ls reporting_coreneuron/*.h5
 
-    - name: live debug session, comment out
-      if: failure()
-      uses: mxschmitt/action-tmate@v3
+    # - name: live debug session, comment out
+    #   if: failure()
+    #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -59,15 +59,16 @@ jobs:
         sudo apt-get update
         sudo apt-get install mpich libmpich-dev libhdf5-mpich-dev hdf5-tools
 
-    - name: Setup python virtual env
-      run: |
-        python -m venv venv
+    # - name: Setup python virtual env
+    #   run: |
+    #     python -m venv venv
 
     - name: Install libsonata
       if: steps.cache-libsonata.outputs.cache-hit != 'true'
       run: |
+        python -m venv venv
         . ./venv/bin/activate
-        CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata@${{ env.LIBSONATA_BRANCH }}
+        CC=mpicc CXX=mpic++ python -m pip install git+https://github.com/BlueBrain/libsonata@${{ env.LIBSONATA_BRANCH }}
 
     - name: Cache libsonatareport
       id: cache-libsonatareport

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -98,14 +98,14 @@ jobs:
       if: steps.cache-neuron.outputs.cache-hit != 'true'
       run: |
         export SONATAREPORT_DIR=$(pwd)/libsonatareport/build/install
+        sudo apt-get install flex libfl-dev bison ninja-build
+        . ./venv/bin/activate
         git clone --branch=${{ env.NEURON_BRANCH }} https://github.com/neuronsimulator/nrn.git
         cd nrn
         if [[ ${{ env.NEURON_BRANCH }} == 'master' ]]; then
           git checkout ${{ env.NEURON_COMMIT_ID }}
         fi
-        sudo apt-get install flex libfl-dev bison ninja-build
-        . ./venv/bin/activate
-        python -m pip install --upgrade pip -r nrn/nrn_requirements.txt
+        python -m pip install --upgrade pip -r nrn_requirements.txt
         mkdir build && cd build
         cmake -G Ninja -DPYTHON_EXECUTABLE=$(which python) -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_INTERVIEWS=OFF \
           -DNRN_ENABLE_CORENEURON=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCORENRN_ENABLE_REPORTING=ON -DCMAKE_PREFIX_PATH=$SONATAREPORT_DIR ..

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -64,10 +64,7 @@ jobs:
       run: |
         python -m venv venv
         . ./venv/bin/activate
-        pip install -U pip setuptools wheel
-        git clone --branch "${{ env.LIBSONATA_BRANCH }}" --depth 1 https://github.com/BlueBrain/libsonata.git
-        cd libsonata
-        pip install .
+        CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata
 
     - name: Cache libsonatareport
       id: cache-libsonatareport

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -45,6 +45,11 @@ jobs:
         LIBSONATA_REPORT_BRANCH=$(echo $COMMIT_MESSAGE | grep -Po 'LIBSONATA_REPORT_BRANCH=\K[0-9a-zA-Z/_.\-]*' || true)
         if [[ ! -z $LIBSONATA_REPORT_BRANCH ]]; then echo "LIBSONATA_REPORT_BRANCH=$LIBSONATA_REPORT_BRANCH" >> $GITHUB_ENV; fi
 
+    - name: Install hdf5-mpich
+      run: |
+        sudo apt-get update
+        sudo apt-get install mpich libmpich-dev libhdf5-mpich-dev hdf5-tools
+
     - name: Cache python virtual env
       id: cache-venv
       uses: actions/cache@v3
@@ -53,11 +58,6 @@ jobs:
       with:
         path: venv
         key: build-libsonata-${{ env.LIBSONATA_BRANCH }} # todo: add python version
-
-    - name: Install hdf5-mpich
-      run: |
-        sudo apt-get update
-        sudo apt-get install mpich libmpich-dev libhdf5-mpich-dev hdf5-tools
 
     - name: Install libsonata
       if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -112,11 +112,16 @@ jobs:
         cmake --build . --parallel
         cmake --build . --target install
 
+    - name: Install mpi4py
+      if: steps.cache-venv.outputs.cache-hit != 'true'
+      run: |
+        . ./venv/bin/activate
+        pip install mpi4py
+
     - name: Build h5py with the local hdf5
       run: |
         . ./venv/bin/activate
         pip install cython numpy wheel pkgconfig
-        pip install mpi4py
         CC="mpicc" HDF5_MPI="ON" HDF5_INCLUDEDIR=/usr/include/hdf5/mpich HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich \
           pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
 
@@ -155,6 +160,6 @@ jobs:
         mpirun -np 2 special -mpi -python $NEURODAMUS_PYTHON/init.py --configFile=simulation_sonata_coreneuron.json
         ls reporting_coreneuron/*.h5
 
-    - name: live debug session, comment out
-      if: failure()
-      uses: mxschmitt/action-tmate@v3
+    # - name: live debug session, comment out
+    #   if: failure()
+    #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -50,18 +50,23 @@ jobs:
         sudo apt-get update
         sudo apt-get install mpich libmpich-dev libhdf5-mpich-dev hdf5-tools
 
+    - name: Setup python virtual env
+      run: |
+        python -m venv venv
+
     - name: Cache libsonata
       id: cache-libsonata
       uses: actions/cache@v3
       env:
         cache-name: cache-libsonata
       with:
-        path: ${{ github.workspace }}/libsonata
+        path: venv
         key: build-libsonata-${{ env.LIBSONATA_BRANCH }}
 
     - name: Install libsonata
       if: steps.cache-libsonata.outputs.cache-hit != 'true'
       run: |
+        . ./venv/bin/activate
         CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata@${{ env.LIBSONATA_BRANCH }}
 
     - name: Cache libsonatareport
@@ -93,8 +98,9 @@ jobs:
         key: build-neuron-${{ env.NEURON_BRANCH }}-${{ env.NEURON_COMMIT_ID }}
 
     - name: Install NEURON
-      if: steps.cache-neuron.outputs.cache-hit != 'true'
+      # if: steps.cache-neuron.outputs.cache-hit != 'true'
       run: |
+        . ./venv/bin/activate
         sudo apt-get install flex libfl-dev bison ninja-build
         pip install -U pip setuptools
         pip install "cython<3" pytest sympy
@@ -112,6 +118,7 @@ jobs:
 
     - name: Build h5py with the local hdf5
       run: |
+        . ./venv/bin/activate
         pip install -U pip setuptools
         pip install cython numpy wheel pkgconfig
         MPICC="mpicc -shared" pip install --no-cache-dir --no-binary=mpi4py mpi4py
@@ -120,6 +127,7 @@ jobs:
 
     - name: Install neurodamus
       run: |
+        . ./venv/bin/activate
         pip install .
 
     - name: Build models
@@ -135,6 +143,7 @@ jobs:
 
     - name: Example run
       run: |
+        . ./venv/bin/activate
         export PYTHONPATH=$(pwd)/nrn/build/lib/python:$PYTHONPATH
         cp neurodamus/data/hoc/* tests/share/hoc/
         export HOC_LIBRARY_PATH=$(pwd)/tests/share/hoc

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -160,6 +160,6 @@ jobs:
         mpirun -np 2 special -mpi -python $NEURODAMUS_PYTHON/init.py --configFile=simulation_sonata_coreneuron.json
         ls reporting_coreneuron/*.h5
 
-    # - name: live debug session, comment out
-    #   if: failure()
-    #   uses: mxschmitt/action-tmate@v3
+    - name: live debug session, comment out
+      if: failure()
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -59,17 +59,15 @@ jobs:
         sudo apt-get update
         sudo apt-get install mpich libmpich-dev libhdf5-mpich-dev hdf5-tools
 
-    - name: Setup python virtual env
+    - name: Install libsonata
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         python -m venv venv
         . ./venv/bin/activate
         pip install -U pip setuptools
-
-    - name: Install libsonata
-      if: steps.cache-venv.outputs.cache-hit != 'true'
-      run: |
-        . ./venv/bin/activate
-        CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata@${{ env.LIBSONATA_BRANCH }}
+        git clone --branch "${{ env.LIBSONATA_BRANCH }}" --depth 1 https://github.com/BlueBrain/libsonata.git
+        cd libsonata
+        pip install .
 
     - name: Cache libsonatareport
       id: cache-libsonatareport
@@ -104,29 +102,24 @@ jobs:
       run: |
         export SONATAREPORT_DIR=$(pwd)/libsonatareport/build/install
         git clone --branch=${{ env.NEURON_BRANCH }} https://github.com/neuronsimulator/nrn.git
+        cd nrn
         if [[ ${{ env.NEURON_BRANCH }} == 'master' ]]; then
           git checkout ${{ env.NEURON_COMMIT_ID }}
         fi
         sudo apt-get install flex libfl-dev bison ninja-build
         . ./venv/bin/activate
         python -m pip install --upgrade pip -r nrn/nrn_requirements.txt
-        cd nrn
         mkdir build && cd build
         cmake -G Ninja -DPYTHON_EXECUTABLE=$(which python) -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_INTERVIEWS=OFF \
           -DNRN_ENABLE_CORENEURON=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCORENRN_ENABLE_REPORTING=ON -DCMAKE_PREFIX_PATH=$SONATAREPORT_DIR ..
         cmake --build . --parallel
         cmake --build . --target install
 
-    - name: Build mpi4Py
-      if: steps.cache-venv.outputs.cache-hit != 'true'
-      run: |
-        . ./venv/bin/activate
-        pip install mpi4py
-
     - name: Build h5py with the local hdf5
       run: |
         . ./venv/bin/activate
         pip install cython numpy wheel pkgconfig
+        pip install mpi4py
         CC="mpicc" HDF5_MPI="ON" HDF5_INCLUDEDIR=/usr/include/hdf5/mpich HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich \
           pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
 

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -14,11 +14,12 @@ on:
         default: 'master'
       LIBSONATA_REPORT_BRANCH:
         description: 'libsonatareport branch to use'
-        required: false
+        required: true
+        default: '1.2.3'
 
 env:
   NEURON_COMMIT_ID: '13654b3'
-  LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
+  # LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
 
 jobs:
   simulation:
@@ -56,12 +57,13 @@ jobs:
         cache-name: cache-libsonatareport
       with:
         path: ${{ github.workspace }}/libsonatareport
-        key: build-libsonatareport-${{ env.LIBSONATA_REPORT_TAG }}
+        key: build-libsonatareport-${{ github.event.inputs.LIBSONATA_REPORT_BRANCH }}
 
     - name: Install libsonatareport
       if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
-        git clone --branch="${{ env.LIBSONATA_REPORT_TAG}}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
+        echo "LIBSONATA_REPORT_BRANCH" ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH }}
+        git clone --branch="${{ github.event.inputs.LIBSONATA_REPORT_BRANCH }}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON ..

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -14,11 +14,11 @@ on:
         default: 'master'
       LIBSONATA_REPORT_BRANCH:
         description: 'libsonatareport branch to use'
-        required: true
-        default: '1.2.3'
+        required: false
 
 env:
   NEURON_COMMIT_ID: '13654b3'
+  LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
 
 jobs:
   simulation:
@@ -56,12 +56,12 @@ jobs:
         cache-name: cache-libsonatareport
       with:
         path: ${{ github.workspace }}/libsonatareport
-        key: build-libsonatareport-${{ inputs.LIBSONATA_REPORT_BRANCH }}
+        key: build-libsonatareport-${{ env.LIBSONATA_REPORT_TAG }}
 
     - name: Install libsonatareport
       if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
-        git clone --branch="${{ inputs.LIBSONATA_REPORT_BRANCH }}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
+        git clone --branch="${{ env.LIBSONATA_REPORT_TAG}}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON ..
@@ -79,7 +79,7 @@ jobs:
         key: build-neuron-${{ env.NEURON_COMMIT_ID }}
 
     - name: Install NEURON
-      if: steps.cache-neuron.outputs.cache-hit != 'true' && ${{ inputs.NEURON_BRANCH }} == 'master'
+      if: steps.cache-neuron.outputs.cache-hit != 'true'
       run: |
         sudo apt-get install flex libfl-dev bison ninja-build
         pip install -U pip setuptools

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -13,11 +13,11 @@ on:
         required: false
       LIBSONATA_REPORT_BRANCH:
         description: 'libsonatareport branch to use'
-        required: false
+        required: true
+        default: '1.2.3'
 
 env:
   NEURON_COMMIT_ID: '13654b3'
-  LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
 
 jobs:
   simulation:
@@ -55,12 +55,12 @@ jobs:
         cache-name: cache-libsonatareport
       with:
         path: ${{ github.workspace }}/libsonatareport
-        key: build-libsonatareport-${{ env.LIBSONATA_REPORT_TAG }}
+        key: build-libsonatareport-$LIBSONATA_REPORT_BRANCH
 
     - name: Install libsonatareport
       if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
-        git clone --branch="${{ env.LIBSONATA_REPORT_TAG}}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
+        git clone --branch="${LIBSONATA_REPORT_BRANCH}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON ..

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         python -m venv venv
         . ./venv/bin/activate
-        pip install -U pip setuptools
+        pip install -U pip setuptools wheel
         git clone --branch "${{ env.LIBSONATA_BRANCH }}" --depth 1 https://github.com/BlueBrain/libsonata.git
         cd libsonata
         pip install .
@@ -158,6 +158,6 @@ jobs:
         mpirun -np 2 special -mpi -python $NEURODAMUS_PYTHON/init.py --configFile=simulation_sonata_coreneuron.json
         ls reporting_coreneuron/*.h5
 
-    # - name: live debug session, comment out
-    #   if: failure()
-    #   uses: mxschmitt/action-tmate@v3
+    - name: live debug session, comment out
+      if: failure()
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -10,15 +10,20 @@ on:
     inputs:
       NEURON_BRANCH:
         description: 'NEURON branch to use'
-        required: true
-        default: 'master'
+        required: false
       LIBSONATA_REPORT_BRANCH:
         description: 'libsonatareport branch to use'
         required: false
+      LIBSONATA_BRANCH:
+        description: 'libsonata branch to use'
+        required: false
+
 
 env:
   NEURON_COMMIT_ID: '13654b3'
-  LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
+  NEURON_BRANCH: ${{ inputs.LIBSONATA_REPORT_BRANCH || 'master' }}
+  LIBSONATA_REPORT_BRANCH: ${{ inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
+  LIBSONATA_BRANCH: ${{ inputs.LIBSONATA_BRANCH || 'v0.1.26' }}
 
 jobs:
   simulation:
@@ -45,9 +50,19 @@ jobs:
         sudo apt-get update
         sudo apt-get install mpich libmpich-dev libhdf5-mpich-dev hdf5-tools
 
+    - name: Cache libsonata
+      id: cache-libsonata
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-libsonata
+      with:
+        path: ${{ github.workspace }}/libsonata
+        key: build-libsonata-${{ env.LIBSONATA_BRANCH }}
+
     - name: Install libsonata
+      if: steps.cache-libsonata.outputs.cache-hit != 'true'
       run: |
-        CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata
+        CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata@${{ env.LIBSONATA_BRANCH }}
 
     - name: Cache libsonatareport
       id: cache-libsonatareport
@@ -56,12 +71,12 @@ jobs:
         cache-name: cache-libsonatareport
       with:
         path: ${{ github.workspace }}/libsonatareport
-        key: build-libsonatareport-${{ env.LIBSONATA_REPORT_TAG }}
+        key: build-libsonatareport-${{ env.LIBSONATA_REPORT_BRANCH }}
 
     - name: Install libsonatareport
       if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
-        git clone --branch="${{ env.LIBSONATA_REPORT_TAG}}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
+        git clone --branch="${{ env.LIBSONATA_REPORT_BRANCH}}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON ..
@@ -70,13 +85,12 @@ jobs:
 
     - name: Cache NEURON
       id: cache-neuron
-      if: ${{ inputs.NEURON_BRANCH }} == 'master'
       uses: actions/cache@v3
       env:
         cache-name: cache-neuron
       with:
         path: ${{ github.workspace }}/nrn
-        key: build-neuron-${{ env.NEURON_COMMIT_ID }}
+        key: build-neuron-${{ env.NEURON_BRANCH }}-${{ env.NEURON_COMMIT_ID }}
 
     - name: Install NEURON
       if: steps.cache-neuron.outputs.cache-hit != 'true'
@@ -85,9 +99,9 @@ jobs:
         pip install -U pip setuptools
         pip install "cython<3" pytest sympy
         export SONATAREPORT_DIR=$(pwd)/libsonatareport/build/install
-        git clone --branch=${{ inputs.NEURON_BRANCH }} https://github.com/neuronsimulator/nrn.git
+        git clone --branch=${{ env.NEURON_BRANCH }} https://github.com/neuronsimulator/nrn.git
         cd nrn
-        if [[ ${{ inputs.NEURON_BRANCH }} == 'master' ]]; then
+        if [[ ${{ env.NEURON_BRANCH }} == 'master' ]]; then
           git checkout ${{ env.NEURON_COMMIT_ID }}
         fi
         mkdir build && cd build

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -14,11 +14,11 @@ on:
         default: 'master'
       LIBSONATA_REPORT_BRANCH:
         description: 'libsonatareport branch to use'
-        required: false
+        required: true
+        default: '1.2.3'
 
 env:
   NEURON_COMMIT_ID: '13654b3'
-  LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
 
 jobs:
   simulation:
@@ -56,12 +56,12 @@ jobs:
         cache-name: cache-libsonatareport
       with:
         path: ${{ github.workspace }}/libsonatareport
-        key: build-libsonatareport-${{ env.LIBSONATA_REPORT_TAG }}
+        key: build-libsonatareport-${{ inputs.LIBSONATA_REPORT_BRANCH }}
 
     - name: Install libsonatareport
       if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
-        git clone --branch="${{ env.LIBSONATA_REPORT_TAG}}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
+        git clone --branch="${{ inputs.LIBSONATA_REPORT_BRANCH }}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON ..
@@ -79,7 +79,7 @@ jobs:
         key: build-neuron-${{ env.NEURON_COMMIT_ID }}
 
     - name: Install NEURON
-      if: steps.cache-neuron.outputs.cache-hit != 'true'
+      if: steps.cache-neuron.outputs.cache-hit != 'true' && ${{ inputs.NEURON_BRANCH }} == 'master'
       run: |
         sudo apt-get install flex libfl-dev bison ninja-build
         pip install -U pip setuptools

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -13,11 +13,11 @@ on:
         required: false
       LIBSONATA_REPORT_BRANCH:
         description: 'libsonatareport branch to use'
-        required: true
-        default: '1.2.3'
+        required: false
 
 env:
   NEURON_COMMIT_ID: '13654b3'
+  LIBSONATA_REPORT_TAG: ${{ github.event.inputs.LIBSONATA_REPORT_BRANCH || '1.2.3' }}
 
 jobs:
   simulation:
@@ -55,12 +55,12 @@ jobs:
         cache-name: cache-libsonatareport
       with:
         path: ${{ github.workspace }}/libsonatareport
-        key: build-libsonatareport-$LIBSONATA_REPORT_BRANCH
+        key: build-libsonatareport-${{ env.LIBSONATA_REPORT_TAG }}
 
     - name: Install libsonatareport
       if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
-        git clone --branch="${LIBSONATA_REPORT_BRANCH}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
+        git clone --branch="${{ env.LIBSONATA_REPORT_TAG}}" https://github.com/BlueBrain/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON ..


### PR DESCRIPTION
## Context
This PR speeds up the GitHub actions workflow by caching large packages to avoid rebuilding each time. Caches for NEURON, libsonata and libsonatareport are created based on the preliminary versions set as the workflow env variables, and will be reused in the later tests in case of the same versions. Users can overwrite the versions and rebuild the packages by commit msgs or using manual workflow_dispatch variables.

## Scope
Github actions workflow `simulation_test.yaml`

## Testing

## Review
* [x] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
