### PR TITLE
Fix record_spikes for load balancing

### DIFF
--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -418,10 +418,11 @@ class CellManagerBase(_CellManager):
         spikevec, idvec = append_spike_vecs or (Nd.Vector(), Nd.Vector())
         if gids is None:
             gids = self._local_nodes.final_gids()
+            gid_offset = self._local_nodes.offset
 
         for gid in gids:
             # only want to collect spikes of cell pieces with the soma (i.e. the real gid)
-            if not self._binfo or self._binfo.thishost_gid(gid) == gid:
+            if not self._binfo or self._binfo.thishost_gid(gid - gid_offset) + gid_offset == gid:
                 self._pc.spike_record(gid, spikevec, idvec)
         return spikevec, idvec
 


### PR DESCRIPTION
## Context
After https://github.com/BlueBrain/neurodamus/pull/148, we are writing raw gids in `Nd.BalanceInfo` instead of final gids with offsets. Such change is missing in `record_spikes()` leading to no spike written in the report with NEURON while lb mode is enabled.

## Scope
Fix in the function `cell_distributer.py: record_spikes`.

## Testing
WIP

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
