### PR TITLE
Avoid calling cleanup from destructor

### DIFF
--- a/neurodamus/commands.py
+++ b/neurodamus/commands.py
@@ -11,6 +11,8 @@ from docopt import docopt
 from os.path import abspath
 from pathlib import Path
 
+from neurodamus.utils.timeit import TimerManager
+
 from . import Neurodamus
 from .core import MPI, OtherRankError
 from .core.configuration import ConfigurationError, LogLevel, EXCEPTION_NODE_FILENAME
@@ -81,6 +83,7 @@ def neurodamus(args=None):
 
     try:
         Neurodamus(config_file, True, logging_level=log_level, **options).run()
+        TimerManager.timeit_show_stats()
     except ConfigurationError as e:  # Common, only show error in Rank 0
         if MPI._rank == 0:           # Use _rank so that we avoid init
             logging.error(str(e))

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1568,7 +1568,6 @@ class Neurodamus(Node):
     def __init__(
         self, config_file,
         auto_init=True,
-        cleanup_atexit=True,
         logging_level=None,
         **user_opts
     ):


### PR DESCRIPTION
## Context
Neurodamus used to ensure `cleanup` was called by calling it from the destructor of the `Neurodamus` class.

However, depending on the python version, this could lead to crashes as some objects from `Node` eventually were already destroyed.

To workaround this problem, at some point we introduced the `cleanup_atexit` parameter which would skip over this procedure, and notably multiscale_run was using it. However this was not a solution as cleanup was not being called.

## Scope
This PR fixes this long standing issue. Cleanup is now called directly from the top-level `run()` function. It can still be avoided if the user really wants to keep the data, with the parameter `cleanup=False`
 
## Testing
CI is happy.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
