### PR TITLE
Trigger workflow when pushing to main

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -4,6 +4,8 @@ on:
     # every evening at 20:00 UTC
     - cron: '0 20 * * *'
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -4,6 +4,7 @@ on:
     # every evening at 20:00 UTC
     - cron: '0 20 * * *'
   pull_request:
+  push:
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
## Context
This PR will enable the workflow when merging a branch to `main`. This will allow to build caches if needed for the default `main` branch immediately after merging. And PRs from other branches can restore the caches from `main` directly instead of building caches for each branch.

## Scope
`simulation_test.yml`

## Review
* [x] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
