### PR TITLE
[BBPBGLIB-1175] Handle deleted sections correctly

### DIFF
--- a/neurodamus/connection.py
+++ b/neurodamus/connection.py
@@ -271,7 +271,7 @@ class Connection(ConnectionBase):
             syn_params['location'] = syn_point.x[0]
             section = syn_point.sclst[0]
 
-            if not section.exists():
+            if section is None or not section.exists():
                 target_point_str = "({0.isec:.0f} {0.ipt:.0f} {0.offset:.4f})".format(syn_params)
                 logging.warning("SKIPPED Synapse %s on gid %d. Src gid: %d. Deleted TPoint %s",
                                 base_id + i, self.tgid, self.sgid, target_point_str)

--- a/neurodamus/target_manager.py
+++ b/neurodamus/target_manager.py
@@ -649,7 +649,7 @@ class TPointList:
             # Called with a section and a point
             section, point = args
             self.x.append(point)
-            self.sclst.append(Nd.SectionRef(section.sec))  # Create and append a SectionRef
+            self.sclst.append(section)  # Create and append a SectionRef
         else:
             raise ValueError("append() takes 1 or 2 arguments ({} given)".format(len(args)))
 


### PR DESCRIPTION
## Context
User reported an error when creating synapse points on deleted sections. This kind of synapses should have been skipped by `Connection::add_synapses()`. This PR handles deleted sections correctly so that they are skipped.

## Scope
In `target_manager.py` and `connection.py`, deleted sections are added to TPointList as `None` type, and skipped by `Connection::add_synapses()`.

## Testing
n/a

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
