### PR TITLE
Update ngv test to use V10 emodels

### DIFF
--- a/tests/simulations/ngv/circuit_config.json
+++ b/tests/simulations/ngv/circuit_config.json
@@ -11,7 +11,7 @@
                 "populations": {
                     "All": {
                         "type": "biophysical",
-                        "biophysical_neuron_models_dir": "$BASE_DIR/base_circuit/emodels_atp_scan/emodels_atp_1p4",
+                        "biophysical_neuron_models_dir": "$BASE_DIR/base_circuit/emodels_atp_scan/emodels_atp_1p4_v10",
                         "alternate_morphologies": {
                             "neurolucida-asc": "$BASE_DIR/base_circuit/morphologies/fixed_ais_L23PC_20201210/ascii"
                         }


### PR DESCRIPTION
## Context
Following the update of ngv/metabolism MOD files (https://github.com/BlueBrain/neurodamus-models/pull/14), the v10 emodels should be used in the ngv test. This PR updates the ngv test config file in the neurodamus unit tests.

## Scope
Update `tests/simulations/ngv/circuit_config.json`, the same as `blueconfigs/sonataconf-quick-multiscale`.

## Testing
The existing `tests/scientific-ngv`.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
