### PR TITLE
Fix multiple issues with Memory Load Balance for MMB run

### DIFF
--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -199,6 +199,7 @@ class CellManagerBase(_CellManager):
             return
         conf = self._circuit_conf
         _loader = _loader or self._node_loader
+        cycle = loader_opts.pop("cycle_i", None)
         loader_f = (lambda *args: _loader(*args, **loader_opts)) if loader_opts else _loader
 
         logging.info("Reading Nodes (METype) info from '%s'", conf.CellLibraryFile)
@@ -210,7 +211,6 @@ class CellManagerBase(_CellManager):
         if not load_balancer or SimConfig.dry_run:
             gidvec, me_infos, *cell_counts = self._load_nodes(loader_f)
         elif load_balancer and SimConfig.loadbal_mode == LoadBalanceMode.Memory:
-            cycle = loader_opts.get("cycle_i", 0)
             gidvec, me_infos, *cell_counts = self._load_nodes_balance_mem(loader_f,
                                                                           load_balancer,
                                                                           cycle)

--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -256,6 +256,8 @@ class CellManagerBase(_CellManager):
         targetspec: TargetSpec = self._target_spec
 
         population = targetspec.population
+        # TODO: Remove slicing?
+        logging.warning("SLICING: Loading cells for cycle %d and rank %d", cycle_i, MPI.rank)
         all_gids = load_balancer.get(population, {}).get((MPI.rank, cycle_i), [])
         all_gids = numpy.array(all_gids, dtype="uint32")
         logging.debug("Loading %d cells in rank %d", len(all_gids), MPI.rank)

--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -256,8 +256,6 @@ class CellManagerBase(_CellManager):
         targetspec: TargetSpec = self._target_spec
 
         population = targetspec.population
-        # TODO: Remove slicing?
-        logging.warning("SLICING: Loading cells for cycle %d and rank %d", cycle_i, MPI.rank)
         all_gids = load_balancer.get(population, {}).get((MPI.rank, cycle_i), [])
         all_gids = numpy.array(all_gids, dtype="uint32")
         logging.debug("Loading %d cells in rank %d", len(all_gids), MPI.rank)

--- a/neurodamus/io/cell_readers.py
+++ b/neurodamus/io/cell_readers.py
@@ -97,6 +97,7 @@ def load_sonata(circuit_conf, all_gids, stride=1, stride_offset=0, *,
         log_verbose("Sonata dry run mode: looking for unique metype instances")
         meinfos = METypeManager()
         # Get global METype counts (computed in rank0, broadcasted)
+        logging.warning("calling _retrieve_unique_metypes from load_base_info_dry_run")
         metype_gids, counts = _retrieve_unique_metypes(node_pop, all_gids)
         dry_run_stats.metype_counts += counts
         dry_run_stats.pop_metype_gids[node_population] = metype_gids

--- a/neurodamus/io/cell_readers.py
+++ b/neurodamus/io/cell_readers.py
@@ -97,7 +97,6 @@ def load_sonata(circuit_conf, all_gids, stride=1, stride_offset=0, *,
         log_verbose("Sonata dry run mode: looking for unique metype instances")
         meinfos = METypeManager()
         # Get global METype counts (computed in rank0, broadcasted)
-        logging.warning("calling _retrieve_unique_metypes from load_base_info_dry_run")
         metype_gids, counts = _retrieve_unique_metypes(node_pop, all_gids)
         dry_run_stats.metype_counts += counts
         dry_run_stats.pop_metype_gids[node_population] = metype_gids

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -451,6 +451,8 @@ class Node:
         else:
             loader_opts = {}
 
+        loader_opts["cycle_i"] = self._cycle_i
+
         # Check dynamic attributes required before loading cells
         SimConfig.check_cell_requirements(self.target_manager)
 

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -387,7 +387,7 @@ class Node:
                 cell_distributor.load_nodes(None, loader_opts={"load_mode": "load_nodes_metype",
                                                                "dry_run_stats": self._dry_run_stats}
                                             )
-                alloc, _, _ = self._dry_run_stats.distribute_cells(
+                alloc, _, _ = self._dry_run_stats.distribute_cells_with_validation(
                     MPI.size,
                     SimConfig.modelbuilding_steps,
                     DryRunStats._MEMORY_USAGE_PER_METYPE_FILENAME
@@ -1804,7 +1804,8 @@ class Neurodamus(Node):
             self._dry_run_stats.display_node_suggestions()
             ranks = self._dry_run_stats.get_num_target_ranks(SimConfig.num_target_ranks)
             self._dry_run_stats.collect_all_mpi()
-            self._dry_run_stats.distribute_cells(ranks, SimConfig.modelbuilding_steps)
+            self._dry_run_stats.distribute_cells_with_validation(ranks,
+                                                                 SimConfig.modelbuilding_steps)
             return
         if not SimConfig.simulate_model:
             self.sim_init()

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -398,19 +398,6 @@ class Node:
             for pop, ranks in alloc.items():
                 for rank, gids in ranks.items():
                     logging.debug(f"Population: {pop}, Rank: {rank}, Number of GIDs: {len(gids)}")
-            if MPI.rank == 0:
-                unique_ranks = set(
-                    rank[0] if isinstance(rank, tuple) else rank
-                    for pop in alloc.values()
-                    for rank in pop.keys()
-                )
-                logging.debug("Unique ranks in allocation file: %s", len(unique_ranks))
-                if MPI.size != len(unique_ranks):
-                    raise ConfigurationError(
-                        "The number of ranks in the allocation file is different from the number "
-                        "of ranks in the current run. The allocation file was created with a "
-                        "different number of ranks."
-                    )
             return alloc
 
         # Build load balancer as per requested options

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -397,7 +397,6 @@ class Node:
             for pop, ranks in alloc.items():
                 for rank, gids in ranks.items():
                     logging.debug(f"Population: {pop}, Rank: {rank}, Number of GIDs: {len(gids)}")
-                    logging.debug(f"First 5 GIDs: {gids[:5]}")
             return alloc
 
         # Build load balancer as per requested options
@@ -432,7 +431,6 @@ class Node:
         """Instantiate and distributes the cells of the network.
         Any targets will be updated to know which cells are local to the cpu.
         """
-        logging.warning("Load Balance: %s", load_balance)
         if SimConfig.dry_run:
             logging.info("Memory usage after inizialization:")
             print_mem_usage()
@@ -1628,7 +1626,6 @@ class Neurodamus(Node):
     def _build_model(self):
         log_stage("================ CALCULATING LOAD BALANCE ================")
         load_bal = self.compute_load_balance()
-        logging.debug("Load balance: %s", load_bal)
         print_mem_usage()
 
         log_stage("==================== BUILDING CIRCUIT ====================")

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -381,7 +381,6 @@ class Node:
             MPI.barrier()
 
             if file_exists:
-                logging.warning("calling import_allocation_stats from compute_load_balance")
                 alloc = import_allocation_stats(filename, self._cycle_i)
             else:
                 logging.warning("Allocation file not found. Generating on-the-fly.")
@@ -391,7 +390,6 @@ class Node:
                 cell_distributor.load_nodes(None, loader_opts={"load_mode": "load_nodes_metype",
                                                                "dry_run_stats": self._dry_run_stats}
                                             )
-                logging.warning("calling distribute_cells_with_validation from compute_load_balance")
                 alloc, _, _ = self._dry_run_stats.distribute_cells_with_validation(
                     MPI.size,
                     SimConfig.modelbuilding_steps,
@@ -510,7 +508,6 @@ class Node:
         if SimConfig.dry_run:
             self._dry_run_stats.collect_all_mpi()
             self._dry_run_stats.export_cell_memory_usage()
-            logging.warning("calling estimate_cell_memory from create_cells")
             self._dry_run_stats.estimate_cell_memory()
 
         # Final bits after we have all cell managers
@@ -1813,7 +1810,6 @@ class Neurodamus(Node):
             ranks = self._dry_run_stats.get_num_target_ranks(SimConfig.num_target_ranks)
             self._dry_run_stats.collect_all_mpi()
             try:
-                logging.warning("Calling distribute_cells_with_validation from .run")
                 self._dry_run_stats.distribute_cells_with_validation(ranks,
                                                                      SimConfig.modelbuilding_steps)
             except RuntimeError as e:

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1804,8 +1804,11 @@ class Neurodamus(Node):
             self._dry_run_stats.display_node_suggestions()
             ranks = self._dry_run_stats.get_num_target_ranks(SimConfig.num_target_ranks)
             self._dry_run_stats.collect_all_mpi()
-            self._dry_run_stats.distribute_cells_with_validation(ranks,
-                                                                 SimConfig.modelbuilding_steps)
+            try:
+                self._dry_run_stats.distribute_cells_with_validation(ranks,
+                                                                     SimConfig.modelbuilding_steps)
+            except RuntimeError as e:
+                logging.error("Dry run failed: %s", e)
             return
         if not SimConfig.simulate_model:
             self.sim_init()

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1121,6 +1121,9 @@ class Node:
         if spike_compress and not is_save_state and not self._is_ngv_run:
             # multisend 13 is combination of multisend(1) + two_phase(8) + two_intervals(4)
             # to activate set spike_compress=(0, 0, 13)
+            if SimConfig.loadbal_mode == LoadBalanceMode.Memory:
+                logging.info("Disabling spike compression for Memory Load Balance")
+                spike_compress = False
             if not isinstance(spike_compress, tuple):
                 spike_compress = (spike_compress, 1, 0)
             self._pc.spike_compress(*spike_compress)

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -590,7 +590,7 @@ class DryRunStats:
                                          num_ranks,
                                          cycles=None,
                                          metype_file=None,
-                                         initial_batch_size=10):
+                                         initial_batch_size=10) -> Tuple[dict, dict, dict]:
         """
         Wrapper function to distribute cells with ever smaller assignment batches until
         all buckets have at least one GID assigned (or fail if no valid distribution is found).

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -237,14 +237,14 @@ def import_allocation_stats(filename, cycle_i=0) -> dict:
         """Converts an object containing defaultdicts of Vectors to standard Python types."""
         result = {}
         for population, vectors in obj.items():
-            result[population] = {key[0]: np.array(vector) for key,
+            result[population] = {key: np.array(vector) for key,
                                   vector in vectors.items() if key[1] == cycle_i}
         return result
 
-    with open(filename, 'rb') as f:
-        compressed_data = f.read()
+    with gzip.open(filename, 'rb') as f:
+        data = pickle.load(f)
 
-    return convert_to_standard_types(pickle.loads(gzip.decompress(compressed_data)))
+    return convert_to_standard_types(data)
 
 
 @run_only_rank0

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -487,7 +487,6 @@ class DryRunStats:
             metype_memory_usage (dict): A dictionary where keys are METype IDs
                                         and values are the memory load of each METype.
         """
-
         logging.info("Distributing cells across %d ranks and %d cycles", num_ranks, cycles)
 
         self.validate_inputs_distribute(num_ranks, batch_size)
@@ -540,12 +539,6 @@ class DryRunStats:
 
             bucket_allocation[pop] = rank_allocation
             bucket_memory[pop] = rank_memory
-
-        print_allocation_stats(bucket_memory)
-        export_allocation_stats(bucket_allocation,
-                                self._ALLOCATION_FILENAME,
-                                num_ranks,
-                                cycles)
 
         return bucket_allocation, bucket_memory, metype_memory_usage
 
@@ -612,6 +605,9 @@ class DryRunStats:
             Tuple[dict, dict, dict]: Returns the same as distribute_cells once a valid distribution
                                      is found.
         """
+        if not cycles:
+            cycles = 1
+
         batch_size = initial_batch_size
         valid_distribution = False
         while not valid_distribution and batch_size > 0:
@@ -625,6 +621,14 @@ class DryRunStats:
                 batch_size -= 1  # Decrease batch size for the next iteration
 
         if batch_size == 0:
-            raise ValueError("Unable to find a valid distribution with the given parameters.")
+            raise RuntimeError("Unable to find a valid distribution with the given parameters. "
+                               "Please try again with a smaller number of ranks or cycles. "
+                               "No allocation file was created.")
+
+        print_allocation_stats(bucket_memory)
+        export_allocation_stats(bucket_allocation,
+                                self._ALLOCATION_FILENAME,
+                                num_ranks,
+                                cycles)
 
         return bucket_allocation, bucket_memory, metype_memory_usage

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -229,7 +229,7 @@ def import_metype_memory_usage(memory_per_metype_file):
     return memory_per_metype
 
 
-def import_allocation_stats(filename, cycle_i=0) -> dict:
+def import_allocation_stats(filename, cycle_i=0, ignore_cache=False) -> dict:
     """
     Import allocation dictionary from serialized pickle file.
     """
@@ -245,7 +245,7 @@ def import_allocation_stats(filename, cycle_i=0) -> dict:
         return result
 
     global _alloc_cache
-    if _alloc_cache is None:
+    if _alloc_cache is None or ignore_cache:
         logging.warning("Loading allocation stats from %s...", filename)
         with gzip.open(filename, 'rb') as f:
             data = pickle.load(f)

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -522,8 +522,6 @@ class DryRunStats:
         def assign_cells_to_bucket(rank_allocation, rank_memory, batch, batch_memory):
             total_memory, (rank_id, cycle_id) = heapq.heappop(buckets)
             logging.debug("Assigning batch to bucket (%d, %d)", rank_id, cycle_id)
-            logging.debug("Batch GIDs: %s", batch)
-            logging.debug("Batch memory: %s", batch_memory)
             rank_allocation[(rank_id, cycle_id)].extend(batch)
             total_memory += batch_memory
             rank_memory[(rank_id, cycle_id)] = total_memory

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -257,6 +257,8 @@ class DryRunStats:
     _ALLOCATION_FILENAME = "allocation"
     _MEMORY_USAGE_PER_METYPE_FILENAME = "memory_per_metype.json"
 
+    _alloc_cache = None
+
     @staticmethod
     def defaultdict_vector():
         return defaultdict(Vector)
@@ -273,7 +275,6 @@ class DryRunStats:
         self.synapse_counts = defaultdict(int)  # [syn_type -> count]
         self.suggested_nodes = 0
         self.synapse_memory_total = 0
-        self._alloc_cache = None
         _, _, self.base_memory, _ = get_task_level_mem_usage()
 
     def import_allocation_stats(self, filename, cycle_i=0, ignore_cache=False) -> dict:
@@ -295,7 +296,7 @@ class DryRunStats:
             logging.warning("Loading allocation stats from %s...", filename)
             with gzip.open(filename, 'rb') as f:
                 data = pickle.load(f)
-            self._alloc_cache = convert_to_standard_types(data)
+            DryRunStats._alloc_cache = convert_to_standard_types(data)
         else:
             logging.warning("Using cached allocation stats.")
 

--- a/tests/integration-e2e/test_dry_run_workflow.py
+++ b/tests/integration-e2e/test_dry_run_workflow.py
@@ -27,7 +27,8 @@ def test_dry_run_workflow(USECASE3):
     GlobalConfig.verbosity = LogLevel.DEBUG
     nd = Neurodamus(
         str(USECASE3 / "simulation_sonata.json"),
-        dry_run=True
+        dry_run=True,
+        num_target_ranks=2
     )
 
     nd.run()
@@ -45,13 +46,13 @@ def test_dry_run_workflow(USECASE3):
     assert nd._dry_run_stats.suggest_nodes(0.3) > 0
 
     # Test that the allocation works and can be saved and loaded
-    rank_allocation, _, cell_memory_usage = nd._dry_run_stats.distribute_cells(2, 1, None, 1)
-    export_allocation_stats(rank_allocation,
+    rank_alloc, _, cell_mem_use = nd._dry_run_stats.distribute_cells_with_validation(2, 1, None, 1)
+    export_allocation_stats(rank_alloc,
                             USECASE3 / "allocation", 2, 1)
-    export_metype_memory_usage(cell_memory_usage, USECASE3 / "memory_per_metype.json")
+    export_metype_memory_usage(cell_mem_use, USECASE3 / "memory_per_metype.json")
 
-    rank_allocation = import_allocation_stats(USECASE3 / "allocation_r2_c1.pkl.gz", 0)
-    rank_allocation_standard = convert_to_standard_types(rank_allocation)
+    rank_alloc = import_allocation_stats(USECASE3 / "allocation_r2_c1.pkl.gz", 0)
+    rank_allocation_standard = convert_to_standard_types(rank_alloc)
 
     expected_items = {
         'NodeA': {0: [1], 1: [2, 3]},
@@ -62,12 +63,12 @@ def test_dry_run_workflow(USECASE3):
 
     # Test that the allocation works and can be saved and loaded
     # and generate allocation file for 1 rank
-    rank_allocation, _, cell_memory_usage = nd._dry_run_stats.distribute_cells(1, 1, None, 1)
-    export_allocation_stats(rank_allocation,
+    rank_alloc, _, cell_mem_use = nd._dry_run_stats.distribute_cells_with_validation(1, 1, None, 1)
+    export_allocation_stats(rank_alloc,
                             USECASE3 / "allocation", 1, 1)
-    export_metype_memory_usage(cell_memory_usage, USECASE3 / "memory_per_metype.json")
-    rank_allocation = import_allocation_stats(USECASE3 / "allocation_r1_c1.pkl.gz")
-    rank_allocation_standard = convert_to_standard_types(rank_allocation)
+    export_metype_memory_usage(cell_mem_use, USECASE3 / "memory_per_metype.json")
+    rank_alloc = import_allocation_stats(USECASE3 / "allocation_r1_c1.pkl.gz")
+    rank_allocation_standard = convert_to_standard_types(rank_alloc)
 
     expected_items = {
         'NodeA': {0: [1, 2, 3]},
@@ -112,7 +113,7 @@ def test_dry_run_workflow_multi():
                     dry_run=True)
     nd.run()
 
-    rank_allocation, _, cell_memory_usage = nd._dry_run_stats.distribute_cells(2)
+    rank_allocation, _, cell_memory_usage = nd._dry_run_stats.distribute_cells_with_validation(2)
     export_allocation_stats(rank_allocation,
                             SIM_DIR / "allocation", 2, 1)
     export_metype_memory_usage(cell_memory_usage, SIM_DIR / "memory_per_metype.json")
@@ -156,7 +157,7 @@ def test_dynamic_distribute():
                     lb_mode="Memory")
     nd.run()
 
-    rank_allocation, _, _ = nd._dry_run_stats.distribute_cells(1, 2)
+    rank_allocation, _, _ = nd._dry_run_stats.distribute_cells_with_validation(1, 2)
     rank_allocation_standard = convert_to_standard_types(rank_allocation)
 
     expected_items = {

--- a/tests/integration-e2e/test_dry_run_workflow.py
+++ b/tests/integration-e2e/test_dry_run_workflow.py
@@ -123,15 +123,16 @@ def test_dry_run_workflow_multi():
     expected_items = {
         'default': {
             (0, 0): [
-                62798, 63257, 64164, 65916, 66069, 66141, 66872, 68224, 68533, 68942, 69840, 64234,
-                64936, 65821, 68856
-            ],
+                62798, 63257, 64164, 65916, 66069, 66141, 66872, 68224,
+                68533, 68942, 69840, 64234, 64936, 65821, 68856
+                ],
             (1, 0): [
-                62946, 63699, 64862, 65952, 66106, 66497, 67667, 68354, 68581, 69531, 63623, 64666,
-                64788, 69878, 67078
-            ]
+                62946, 63699, 64862, 65952, 66106, 66497, 67667, 68354,
+                68581, 69531, 63623, 64666, 64788, 69878, 67078
+                ]
+            }
         }
-    }
+
     assert rank_allocation_standard == expected_items
 
 
@@ -159,19 +160,20 @@ def test_dynamic_distribute():
     nd.run()
 
     rank_allocation, _, _ = nd._dry_run_stats.distribute_cells_with_validation(1, 2)
-    rank_allocation_standard = convert_to_standard_types(rank_allocation)
+    # rank_allocation_standard = convert_to_standard_types(rank_allocation)
 
-    expected_items = {
-        'default': {
-            (0, 0): [
-                62798, 62946, 63257, 63699, 64164, 64862, 65916, 65952, 66069, 66106
-            ],
-            (0, 1): [
-                66141, 66497, 66872, 67667, 68224, 68354, 68533, 68581, 68942, 69531,
-                69840, 63623, 64234, 64666, 64788, 64936, 69878, 65821, 67078, 68856
-            ]
-        }
-    }
+    # expected_items = {
+    #     'default': {
+    #         (0, 0): [
+    #             62798, 63257, 63699, 64862, 65952, 66106, 66497, 67667,
+    #             68354, 68581, 69531, 63623, 64666, 64788, 64936, 69878, 68856
+    #             ],
+    #         (0, 1): [
+    #             62946, 64164, 65916, 66069, 66141, 66872, 68224, 68533,
+    #             68942, 69840, 64234, 65821, 67078
+    #         ]
+    #     }
+    # }
 
-    for key, sub_value in rank_allocation_standard['default'].items():
-        assert set(sub_value) == set(expected_items['default'][key])
+    # for key, sub_value in rank_allocation_standard['default'].items():
+    #     assert set(sub_value) == set(expected_items['default'][key])

--- a/tests/integration-e2e/test_dry_run_workflow.py
+++ b/tests/integration-e2e/test_dry_run_workflow.py
@@ -46,7 +46,7 @@ def test_dry_run_workflow(USECASE3):
     assert nd._dry_run_stats.suggest_nodes(0.3) > 0
 
     # Test that the allocation works and can be saved and loaded
-    rank_alloc, _, cell_mem_use = nd._dry_run_stats.distribute_cells_with_validation(2, 1, None, 1)
+    rank_alloc, _, cell_mem_use = nd._dry_run_stats.distribute_cells_with_validation(2, 1, None)
     export_allocation_stats(rank_alloc,
                             USECASE3 / "allocation", 2, 1)
     export_metype_memory_usage(cell_mem_use, USECASE3 / "memory_per_metype.json")
@@ -55,15 +55,15 @@ def test_dry_run_workflow(USECASE3):
     rank_allocation_standard = convert_to_standard_types(rank_alloc)
 
     expected_items = {
-        'NodeA': {0: [1], 1: [2, 3]},
-        'NodeB': {0: [1], 1: [2]}
+        'NodeA': {(0, 0): [1], (1, 0): [2, 3]},
+        'NodeB': {(0, 0): [1], (1, 0): [2]}
     }
 
     assert rank_allocation_standard == expected_items
 
     # Test that the allocation works and can be saved and loaded
     # and generate allocation file for 1 rank
-    rank_alloc, _, cell_mem_use = nd._dry_run_stats.distribute_cells_with_validation(1, 1, None, 1)
+    rank_alloc, _, cell_mem_use = nd._dry_run_stats.distribute_cells_with_validation(1, 1, None)
     export_allocation_stats(rank_alloc,
                             USECASE3 / "allocation", 1, 1)
     export_metype_memory_usage(cell_mem_use, USECASE3 / "memory_per_metype.json")
@@ -71,8 +71,8 @@ def test_dry_run_workflow(USECASE3):
     rank_allocation_standard = convert_to_standard_types(rank_alloc)
 
     expected_items = {
-        'NodeA': {0: [1, 2, 3]},
-        'NodeB': {0: [1, 2]}
+        'NodeA': {(0, 0): [1, 2, 3]},
+        'NodeB': {(0, 0): [1, 2]}
     }
 
     assert rank_allocation_standard == expected_items
@@ -122,12 +122,13 @@ def test_dry_run_workflow_multi():
 
     expected_items = {
         'default': {
-            0: [
-                62798, 62946, 63257, 63699, 64164, 64862, 65916, 65952, 66069, 66106,
-                69840, 63623, 64234, 64666, 64788, 64936, 69878, 65821, 67078, 68856
+            (0, 0): [
+                62798, 63257, 64164, 65916, 66069, 66141, 66872, 68224, 68533, 68942, 69840, 64234,
+                64936, 65821, 68856
             ],
-            1: [
-                66141, 66497, 66872, 67667, 68224, 68354, 68533, 68581, 68942, 69531
+            (1, 0): [
+                62946, 63699, 64862, 65952, 66106, 66497, 67667, 68354, 68581, 69531, 63623, 64666,
+                64788, 69878, 67078
             ]
         }
     }

--- a/tests/integration-e2e/test_dry_run_workflow.py
+++ b/tests/integration-e2e/test_dry_run_workflow.py
@@ -1,10 +1,44 @@
+import pytest
+import os
 from pathlib import Path
-from neurodamus.utils.memory import import_allocation_stats, export_allocation_stats
-from neurodamus.utils.memory import export_metype_memory_usage
-from test_multicycle_runs import _create_tmpconfig_coreneuron
+from unittest.mock import patch
+from neurodamus.utils.memory import DryRunStats
 from neurodamus.core.configuration import GlobalConfig, LogLevel
 
 SIM_DIR = Path(__file__).parent.parent.absolute() / "simulations"
+
+
+@pytest.fixture
+def neurodamus_instance(request: pytest.FixtureRequest, USECASE3: Path):
+    from neurodamus import Neurodamus
+
+    params = request.param
+    dry_run = params.get('dry_run', True)
+    num_target_ranks = params.get('num_target_ranks', '1')
+    modelbuilding_steps = params.get('modelbuilding_steps', '1')
+    config_file = os.path.basename(params.get('config_file', "simulation_sonata.json"))
+    path_to_config = params.get('path_to_config', USECASE3)
+    lb_mode = params.get('lb_mode', "")
+
+    # print all request parameters
+    print(f"request.dry_run: {dry_run}")
+    print(f"request.num_target_ranks: {num_target_ranks}")
+    print(f"request.modelbuilding_steps: {modelbuilding_steps}")
+    print(f"request.config_file: {config_file}")
+    print(f"request.path_to_config: {path_to_config}")
+    print(f"request.lb_mode: {lb_mode}")
+
+    GlobalConfig.verbosity = LogLevel.DEBUG
+    nd = Neurodamus(
+        str(path_to_config / config_file),
+        dry_run=dry_run,
+        num_target_ranks=num_target_ranks,
+        modelbuilding_steps=modelbuilding_steps,
+        lb_mode=lb_mode
+    )
+    yield nd
+
+    nd = None
 
 
 def convert_to_standard_types(obj):
@@ -15,21 +49,25 @@ def convert_to_standard_types(obj):
     return result
 
 
-def test_dry_run_workflow(USECASE3):
+@pytest.mark.parametrize("neurodamus_instance", [
+    {
+        'dry_run': True,
+        'num_target_ranks': 2,
+        'config_file': "simulation_sonata.json",
+        'path_to_config': SIM_DIR / "usecase3",
+        'lb_mode': ""
+    }
+], indirect=True)
+def test_dry_run_workflow(neurodamus_instance, USECASE3):
     """
     Test that the dry run mode works
+
     """
+    from neurodamus.utils.memory import export_allocation_stats
+    from neurodamus.utils.memory import export_metype_memory_usage
 
-    # Make sure no old cell_memory_usage is used
-    Path(("cell_memory_usage.json")).unlink(missing_ok=True)
-
-    from neurodamus import Neurodamus
     GlobalConfig.verbosity = LogLevel.DEBUG
-    nd = Neurodamus(
-        str(USECASE3 / "simulation_sonata.json"),
-        dry_run=True,
-        num_target_ranks=2
-    )
+    nd = neurodamus_instance
 
     nd.run()
 
@@ -51,7 +89,7 @@ def test_dry_run_workflow(USECASE3):
                             USECASE3 / "allocation", 2, 1)
     export_metype_memory_usage(cell_mem_use, USECASE3 / "memory_per_metype.json")
 
-    rank_alloc = import_allocation_stats(USECASE3 / "allocation_r2_c1.pkl.gz", 0)
+    rank_alloc = nd._dry_run_stats.import_allocation_stats(USECASE3 / "allocation_r2_c1.pkl.gz", 0)
     rank_allocation_standard = convert_to_standard_types(rank_alloc)
 
     expected_items = {
@@ -74,42 +112,123 @@ def test_dry_run_workflow(USECASE3):
 
     assert rank_allocation_standard == expected_items
 
+    Path(("allocation_r1_c1.pkl.gz")).unlink(missing_ok=True)
+    Path(("allocation_r2_c1.pkl.gz")).unlink(missing_ok=True)
 
-def test_dry_run_workflow_multi():
+
+@pytest.mark.parametrize("neurodamus_instance", [
+    {
+        'dry_run': False,
+        'config_file': "simulation_sonata.json",
+        'path_to_config': SIM_DIR / "usecase3",
+        'lb_mode': "Memory"
+    }
+], indirect=True)
+def test_dynamic_distribute(neurodamus_instance):
     """
-    Test that the dry run mode works in multicycle mode
+    Test that the dynamic distribution of cells works properly.
+    The test deletes any old allocation file before running and uses
+    the memory_per_metype.json generated in the previous test to
+    redistribute the cells. Then checks if the new allocation is correct.
     """
 
-    # Make sure no old cell_memory_usage is used
-    Path(("cell_memory_usage.json")).unlink(missing_ok=True)
+    nd = neurodamus_instance
 
-    from neurodamus import Neurodamus
-
-    config_file = str(SIM_DIR / "v5_sonata" / "simulation_config.json")
-    output_dir = str(SIM_DIR / "v5_sonata" / "output_coreneuron")
-    tmp_file = _create_tmpconfig_coreneuron(config_file)
-    GlobalConfig.verbosity = LogLevel.DEBUG
-
-    nd = Neurodamus(tmp_file.name,
-                    output_path=output_dir,
-                    modelbuilding_steps=3,
-                    dry_run=True)
-    nd.run()
-
-    rank_allocation, _, cell_memory_usage = nd._dry_run_stats.distribute_cells_with_validation(2)
-    export_allocation_stats(rank_allocation,
-                            SIM_DIR / "allocation", 2, 1)
-    export_metype_memory_usage(cell_memory_usage, SIM_DIR / "memory_per_metype.json")
-    rank_allocation = import_allocation_stats(SIM_DIR / "allocation_r2_c1.pkl.gz", 0, True)
+    rank_allocation, _, _ = nd._dry_run_stats.distribute_cells_with_validation(2, 1)
     rank_allocation_standard = convert_to_standard_types(rank_allocation)
+    print(rank_allocation_standard)
 
     expected_items = {
-        'default': {
-            (0, 0): [
-                62798, 63257, 64164, 65916, 66069, 66141, 66872, 68224,
-                68533, 68942, 69840, 64234, 69878, 67078
-                ]
-            }
+        'NodeA': {
+            (0, 0): [1],
+            (1, 0): [2, 3]
         }
+    }
 
-    assert rank_allocation_standard == expected_items
+    for key, sub_value in rank_allocation_standard['NodeA'].items():
+        assert set(sub_value) == set(expected_items['NodeA'][key])
+
+
+@pytest.fixture
+def fixed_memory_measurements():
+    with patch('neurodamus.utils.memory.get_mem_usage_kb', return_value=100):
+        with patch('neurodamus.utils.memory.SynapseMemoryUsage.get_memory_usage', return_value=10):
+            yield
+
+
+def test_distribute_cells_multi_pop_multi_cycle(fixed_memory_measurements):
+    """
+    Test that the distribute_cells_with_validation function works with multiple pops and cycles
+    """
+
+    stats = DryRunStats()
+
+    # Mock data for testing
+    stats.metype_memory = {
+        'L4_PC-dSTUT': 50,
+        'L4_MC-dSTUT': 30,
+        'L4_MC-dNAC': 20,
+        'L5_PC-dSTUT': 40
+    }
+    stats.metype_cell_syn_average = {
+        'L4_PC-dSTUT': 5,
+        'L4_MC-dSTUT': 3,
+        'L4_MC-dNAC': 2,
+        'L5_PC-dSTUT': 4
+    }
+    stats.pop_metype_gids = {
+        'NodeA': {
+            'L4_PC-dSTUT': [1, 2, 3],
+            'L4_MC-dSTUT': [4, 5],
+            'L4_MC-dNAC': [6],
+            'L5_PC-dSTUT': [7, 8]
+        },
+        'NodeB': {
+            'L4_PC-dSTUT': [9],
+            'L4_MC-dSTUT': [10, 11],
+            'L4_MC-dNAC': [12, 13],
+            'L5_PC-dSTUT': [14]
+        }
+    }
+
+    # Run the distribute_cells_with_validation function
+    bucket_allocation, bucket_memory, metype_memory_usage = stats.distribute_cells_with_validation(
+        num_ranks=2,
+        cycles=2
+    )
+    rank_allocation_standard = convert_to_standard_types(bucket_allocation)
+    print(rank_allocation_standard)
+    print(bucket_memory)
+
+    expected_allocation = {
+        'NodeA': {
+            (0, 0): [1, 6],
+            (1, 0): [3, 8],
+            (0, 1): [2, 7],
+            (1, 1): [4, 5]
+        },
+        'NodeB': {
+            (0, 0): [9],
+            (1, 0): [11],
+            (0, 1): [10, 14],
+            (1, 1): [12, 13]
+        }
+    }
+    expected_memory = {
+        'NodeA': {
+            (0, 0): 90,
+            (1, 0): 110,
+            (0, 1): 110,
+            (1, 1): 80
+        },
+        'NodeB': {
+            (0, 0): 60,
+            (1, 0): 40,
+            (0, 1): 90,
+            (1, 1): 60
+        }
+    }
+
+    # Assert that the results match the expected values
+    assert rank_allocation_standard == expected_allocation
+    assert bucket_memory == expected_memory

--- a/tests/integration-e2e/test_dry_run_workflow.py
+++ b/tests/integration-e2e/test_dry_run_workflow.py
@@ -20,14 +20,6 @@ def neurodamus_instance(request: pytest.FixtureRequest, USECASE3: Path):
     path_to_config = params.get('path_to_config', USECASE3)
     lb_mode = params.get('lb_mode', "")
 
-    # print all request parameters
-    print(f"request.dry_run: {dry_run}")
-    print(f"request.num_target_ranks: {num_target_ranks}")
-    print(f"request.modelbuilding_steps: {modelbuilding_steps}")
-    print(f"request.config_file: {config_file}")
-    print(f"request.path_to_config: {path_to_config}")
-    print(f"request.lb_mode: {lb_mode}")
-
     GlobalConfig.verbosity = LogLevel.DEBUG
     nd = Neurodamus(
         str(path_to_config / config_file),
@@ -136,7 +128,6 @@ def test_dynamic_distribute(neurodamus_instance):
 
     rank_allocation, _, _ = nd._dry_run_stats.distribute_cells_with_validation(2, 1)
     rank_allocation_standard = convert_to_standard_types(rank_allocation)
-    print(rank_allocation_standard)
 
     expected_items = {
         'NodeA': {
@@ -197,8 +188,6 @@ def test_distribute_cells_multi_pop_multi_cycle(fixed_memory_measurements):
         cycles=2
     )
     rank_allocation_standard = convert_to_standard_types(bucket_allocation)
-    print(rank_allocation_standard)
-    print(bucket_memory)
 
     expected_allocation = {
         'NodeA': {


### PR DESCRIPTION
## Context
As detailed in [https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-1152](https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-1152), multiple issues came up when trying to use the `neurodamus` memory load balance to run the MMB circuit.

In particular, the issues were a `list index out of range` error (that was caused by ranks/cycle sometimes not having any gids assigned) and an `Unpickling` error that is still misterious in its exact mechanics but that was seemingly caused by a corrupted broadcast of the allocation data.

## Scope
This MR implements a huge reworking of the memory load balance workflow:
-  the `distribute_cells` function is now a subroutine of `distribute_cells_with_validation`. This new function implements directly a check to make sure all ranks/cycle have at least one gid assigned and will automatically rework the distribution with smaller batches in case the condition is not respected. Furthermore, it integrates a dynamic batch size calculation in order to speedup the distribution.
- the `import_allocation_file` has been completely reworked to integrate both a caching mechanism (to avoid reloading the allocation file in every cycle) but also now return only the allocation table for the appropriate rank.
- the load balance memory workflow now correctly supports multi-population circuit
- disable spike compression when `neurodamus` is run in Load Balance Memory mode

## Testing
Due to the nature of the changes, and to standardize them, the test have been completely reworked with the use of fixture and lots of improvements to stability Furthermore, the test to distribute cells in multi-pop and multi cycles has been reworked to use mock object, since the inherent oscillation in memory measurements could lead to different results and distributions.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
