### PR TITLE
Crash test mode

### DIFF
--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -282,7 +282,10 @@ class CellManagerBase(_CellManager):
 
     @mpi_no_errors
     def _instantiate_cells(self, _CellType=None, **_opts):
-        CellType = _CellType or self.CellType
+        if SimConfig.cli_options.checks_only:
+            CellType = lambda gid, *_: EmptyCell(gid, None)
+        else:
+            CellType = _CellType or self.CellType
         assert CellType is not None, "Undefined CellType in Manager"
         Nd.execute("xopen_broadcast_ = 0")
 

--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -282,7 +282,7 @@ class CellManagerBase(_CellManager):
 
     @mpi_no_errors
     def _instantiate_cells(self, _CellType=None, **_opts):
-        if SimConfig.cli_options.crash_test:
+        if SimConfig.crash_test_mode:
             CellType = PointCell
         else:
             CellType = _CellType or self.CellType

--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -23,7 +23,7 @@ from .core.configuration import GlobalConfig, LoadBalanceMode, LogLevel, find_in
 from .core.nodeset import NodeSet
 from .io import cell_readers
 from .lfp_manager import LFPManager
-from .metype import Cell_V6, EmptyCell
+from .metype import Cell_V6, EmptyCell, PointCell
 from .target_manager import TargetSpec
 from .utils import compat
 from .utils.logging import log_verbose, log_all
@@ -282,8 +282,8 @@ class CellManagerBase(_CellManager):
 
     @mpi_no_errors
     def _instantiate_cells(self, _CellType=None, **_opts):
-        if SimConfig.cli_options.checks_only:
-            CellType = lambda gid, *_: EmptyCell(gid, None)
+        if SimConfig.cli_options.crash_test:
+            CellType = PointCell
         else:
             CellType = _CellType or self.CellType
         assert CellType is not None, "Undefined CellType in Manager"

--- a/neurodamus/commands.py
+++ b/neurodamus/commands.py
@@ -60,6 +60,7 @@ def neurodamus(args=None):
         --enable-shm=[ON, OFF]  Enables the use of /dev/shm for coreneuron_input [default: ON]
         --model-stats           Show model stats in CoreNEURON simulations [default: False]
         --dry-run               Dry-run simulation to estimate memory usage [default: False]
+        --checks-only           Skip instantiating cells and synapses, only verify distribution
         --num-target-ranks=<number>  Number of ranks to target for dry-run load balancing
         --coreneuron-direct-mode     Run CoreNeuron in direct memory mode transfered from Neuron,
                                      without writing model data to disk.

--- a/neurodamus/commands.py
+++ b/neurodamus/commands.py
@@ -60,7 +60,7 @@ def neurodamus(args=None):
         --enable-shm=[ON, OFF]  Enables the use of /dev/shm for coreneuron_input [default: ON]
         --model-stats           Show model stats in CoreNEURON simulations [default: False]
         --dry-run               Dry-run simulation to estimate memory usage [default: False]
-        --checks-only           Skip instantiating cells and synapses, only verify distribution
+        --crash-test            Run the simulation with single section cells and single synapses
         --num-target-ranks=<number>  Number of ranks to target for dry-run load balancing
         --coreneuron-direct-mode     Run CoreNeuron in direct memory mode transfered from Neuron,
                                      without writing model data to disk.

--- a/neurodamus/connection.py
+++ b/neurodamus/connection.py
@@ -323,6 +323,17 @@ class Connection(ConnectionBase):
             syn_id = len(self._synapse_sections)
         self._synapse_ids.append(syn_id)
 
+    def add_single(self, cell_manager, syn_params, syn_id):
+        """Add synapse config in target cell"""
+        soma = Nd.SectionRef(sec=cell_manager.get_cell(self.tgid).soma[0])
+        self._synapse_ids.append(syn_id)
+        self._synapse_sections.append(soma)
+        self._synapse_points_x.append(0.5)
+        if self._synapse_params is None:
+            self._synapse_params = [syn_params]
+        else:
+            self._synapse_params.append(syn_params)
+
     # -
     def replay(self, tvec, start_delay=.0):
         """ The synapses connecting these gids are to be activated using

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -591,11 +591,15 @@ class ConnectionManagerBase(object):
             cur_conn.locked = True
 
     # -
-    def _add_synapses(self, cur_conn, syns_params, syn_type_restrict=None, base_id=0):
+    def _add_synapses(self, cur_conn: Connection, syns_params, syn_type_restrict=None, base_id=0):
         if syn_type_restrict:
             syns_params = syns_params[syns_params['synType'] != syn_type_restrict]
-
-        cur_conn.add_synapses(self._target_manager, syns_params, base_id)
+        if len(syns_params) == 0:
+            return
+        if SimConfig.cli_options.crash_test:
+            cur_conn.add_single(self._cell_manager, syns_params[0], base_id)
+        else:
+            cur_conn.add_synapses(self._target_manager, syns_params, base_id)
 
     # -
     def get_population_offsets(self):

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -596,7 +596,7 @@ class ConnectionManagerBase(object):
             syns_params = syns_params[syns_params['synType'] != syn_type_restrict]
         if len(syns_params) == 0:
             return
-        if SimConfig.cli_options.crash_test:
+        if SimConfig.crash_test_mode:
             cur_conn.add_single(self._cell_manager, syns_params[0], base_id)
         else:
             cur_conn.add_synapses(self._target_manager, syns_params, base_id)

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -78,6 +78,7 @@ class CliOptions(ConfigT):
     num_target_ranks = None
     keep_axon = False
     coreneuron_direct_mode = False
+    checks_only = False
 
     # Restricted Functionality support, mostly for testing
 

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -78,7 +78,7 @@ class CliOptions(ConfigT):
     num_target_ranks = None
     keep_axon = False
     coreneuron_direct_mode = False
-    checks_only = False
+    crash_test = False
 
     # Restricted Functionality support, mostly for testing
 

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -239,6 +239,7 @@ class _SimConfig(object):
     dry_run = False
     num_target_ranks = None
     coreneuron_direct_mode = False
+    crash_test_mode = False
 
     _validators = []
     _requisitors = []
@@ -274,6 +275,7 @@ class _SimConfig(object):
         cls.modifications = compat.Map(cls._config_parser.parsedModifications or {})
         cls.cli_options = CliOptions(**(cli_options or {}))
         cls.dry_run = cls.cli_options.dry_run
+        cls.crash_test_mode = cls.cli_options.crash_test
         cls.num_target_ranks = cls.cli_options.num_target_ranks
         # change simulator by request before validator and init hoc config
         if cls.cli_options.simulator:

--- a/neurodamus/metype.py
+++ b/neurodamus/metype.py
@@ -208,6 +208,32 @@ class EmptyCell(BaseCell):
         self.gid = gid
 
 
+class PointCell:
+    """Class representing a minimal, single section cell for dry-runs"""
+
+    def __init__(self, gid, cell_info, _circuit_conf):
+        self.gid = gid
+        self.raw_gid = None
+        self.soma = [Nd.Section(name="soma[0]", cell=self)]
+        self.exc_mini_frequency = float(cell_info.exc_mini_frequency)
+        self.inh_mini_frequency = float(cell_info.inh_mini_frequency)
+        self.synHelperList = []
+        self.synlist = []
+
+    CellRef = property(lambda self: self)
+    CCell = property(lambda self: self)
+    nSecAll = property(lambda _self: 1)
+    all = property(lambda self: [self.soma])
+    input_resistance = property(lambda _self: 1)
+
+    def connect2target(self, target_pp=None):
+        soma_sec = self.soma[0]
+        return Nd.NetCon(soma_sec(1)._ref_v, target_pp, sec=soma_sec)
+
+    def re_init_rng(self, ion_seed):
+        pass
+
+
 # Metadata
 # --------
 

--- a/neurodamus/metype.py
+++ b/neurodamus/metype.py
@@ -223,7 +223,7 @@ class PointCell:
     CellRef = property(lambda self: self)
     CCell = property(lambda self: self)
     nSecAll = property(lambda _self: 1)
-    all = property(lambda self: [self.soma])
+    all = property(lambda self: self.soma)
     input_resistance = property(lambda _self: 1)
 
     def connect2target(self, target_pp=None):

--- a/neurodamus/metype.py
+++ b/neurodamus/metype.py
@@ -217,6 +217,8 @@ class PointCell:
         self.soma = [Nd.Section(name="soma[0]", cell=self)]
         self.exc_mini_frequency = float(cell_info.exc_mini_frequency)
         self.inh_mini_frequency = float(cell_info.inh_mini_frequency)
+        self._threshold_current = float(cell_info.threshold_current)
+        self._hypAmp_current = float(cell_info.holding_current)
         self.synHelperList = []
         self.synlist = []
 
@@ -225,6 +227,8 @@ class PointCell:
     nSecAll = property(lambda _self: 1)
     all = property(lambda self: self.soma)
     input_resistance = property(lambda _self: 1)
+    getThreshold = lambda self: self._threshold_current
+    getHypAmp = lambda self: self._hypAmp_current
 
     def connect2target(self, target_pp=None):
         soma_sec = self.soma[0]

--- a/neurodamus/utils/memory.py
+++ b/neurodamus/utils/memory.py
@@ -462,8 +462,8 @@ class DryRunStats:
     @run_only_rank0
     def distribute_cells(
         self,
-        num_ranks,
-        cycles=None,
+        num_ranks: int,
+        cycles: int = 1,
         metype_file=None,
         batch_size=10
     ) -> Tuple[dict, dict, dict]:
@@ -487,8 +487,6 @@ class DryRunStats:
             metype_memory_usage (dict): A dictionary where keys are METype IDs
                                         and values are the memory load of each METype.
         """
-        if not cycles:
-            cycles = 1
 
         logging.info("Distributing cells across %d ranks and %d cycles", num_ranks, cycles)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,18 @@
 import pytest
 from pathlib import Path
 
-USECASE3 = Path(__file__).parent.absolute() / "simulations" / "usecase3"
+SIM_DIR = Path(__file__).parent.absolute() / "simulations"
+USECASE3 = SIM_DIR / "usecase3"
 
 
 @pytest.fixture(scope="session")
 def rootdir(request):
     return request.config.rootdir
+
+
+@pytest.fixture(scope="session", name="SIM_DIR")
+def sim_data_path():
+    return SIM_DIR
 
 
 @pytest.fixture(scope="session", name="USECASE3")

--- a/tests/integration-e2e/test_crashmode.py
+++ b/tests/integration-e2e/test_crashmode.py
@@ -1,0 +1,37 @@
+import json
+import os
+
+
+def test_crash_test_cell_loading(SIM_DIR, tmp_path):
+    from neurodamus import Node
+    from neurodamus.cell_distributor import CellDistributor
+    from neurodamus.metype import PointCell
+    from neuron import nrn
+    sim_dir = SIM_DIR / "v5_sonata"
+    sim_config_path = sim_dir / "simulation_config.json"
+
+    with open(sim_config_path) as config_fp:
+        config = json.load(config_fp)
+
+    # Replace target with a large one (18k cells)
+    # Test runs in a single rank and its still fast in crash-test mode
+    new_config_path = tmp_path / "simulation_config.json"
+    config["node_set"] = "L4_PC"
+    with open(new_config_path, "w") as new_config:
+        json.dump(config, new_config)
+
+    # Symlink aux files, searched in the same dir
+    for filename in ("circuit_config.json", "node_sets.json"):
+        os.symlink(sim_dir / filename, tmp_path / filename)
+
+    n = Node(str(new_config_path), {"crash_test": True})
+    n.load_targets()
+    n.create_cells()
+
+    cell_manager: CellDistributor = n.circuits.get_node_manager("default")
+    assert len(cell_manager.cells) == 18750
+    cell0 = next(iter(cell_manager.cells))
+    assert isinstance(cell0, PointCell)
+    assert isinstance(cell0.soma, list)
+    assert len(cell0.soma) == 1
+    assert isinstance(cell0.soma[0], nrn.Section)


### PR DESCRIPTION
## Context

Some simulations are pretty heavy, requiring a lot of nodes and time while, unfortunately, some problems only manifest in such very large scenarios. 

In order to improve the experience when testing new circuits, features or debugging a failure we introduce a new "Crash test" mode.

The new mode runs a simplified version of the circuit:
 - Cells feature a single section
 - Connections (between 2 cells) feature a single synapse (to the only section)

Therefore, while results are meaningless, the vast majority of Neurodamus internal machinery runs very quickly, allowing debug sessions to be orders of magnitude faster.

## Scope

 - Added new CLI option `--crash-test`
 - Defined a new full-python cell featuring a single section, with all required attributes
 - Implement a new `create_single()` function in Connection 

## Testing

Ran `sonataconf-sscx-O1` blueconfigs test (1000 cells) in a **single** rank: 
```
real	5m37.478s
user	3m44.838s
sys	0m3.816s
```
including 80 seconds for simulating 100 ms

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
