### PR TITLE
Crash-test mode: Speed up synapse loading

### DIFF
--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -628,7 +628,7 @@ class ConnectionManagerBase(object):
                 log_all(logging.DEBUG, "Source GIDs for debug cell: %s", self.yielded_src_gids)
 
     # -
-    def _iterate_conn_params(self, src_target, dst_target, gids=None, show_progress=False,
+    def _iterate_conn_params(self, src_target, dst_target, gids=None, show_progress=None,
                              mod_override=None):
         """A generator which loads synapse data and yields tuples(sgid, tgid, synapses)
 
@@ -638,7 +638,7 @@ class ConnectionManagerBase(object):
             gids: Use given gids, instead of the circuit target cells. Default: None
             show_progress: Display a progress bar as tgids are processed
         """
-        crash_test_mode = SimConfig.cli_options.crash_test
+        AUTO_PROGRESS_THRESHOLD = 50
         if src_target and src_target.is_void() or dst_target and dst_target.is_void():
             return
 
@@ -655,7 +655,7 @@ class ConnectionManagerBase(object):
         sgid_offset, tgid_offset = self.get_population_offsets()
 
         self._synapse_reader.configure_override(mod_override)
-        self._synapse_reader.preload_data(gids, minimal_mode=crash_test_mode)
+        self._synapse_reader.preload_data(gids, minimal_mode=SimConfig.cli_options.crash_test)
         extra_fields = {}  # Without extra fields, reuse this object
 
         # NOTE: This routine is quite critical, sitting at the core of synapse processing
@@ -663,6 +663,10 @@ class ConnectionManagerBase(object):
         # it might lose some readability.
         # For each tgid we obtain the synapse parameters as a record array. We then split it,
         # without copying, yielding ranges (views) of it.
+
+        if show_progress is None:
+            show_progress = len(gids) >= AUTO_PROGRESS_THRESHOLD
+
         gids = ProgressBar.iter(gids, name="Loading") if show_progress else gids
 
         for base_tgid in gids:

--- a/neurodamus/connection_manager.py
+++ b/neurodamus/connection_manager.py
@@ -638,7 +638,6 @@ class ConnectionManagerBase(object):
             gids: Use given gids, instead of the circuit target cells. Default: None
             show_progress: Display a progress bar as tgids are processed
         """
-        CRASH_TEST_MODE_MAX_CONNS_CELL = 3
         crash_test_mode = SimConfig.cli_options.crash_test
         if src_target and src_target.is_void() or dst_target and dst_target.is_void():
             return
@@ -664,17 +663,12 @@ class ConnectionManagerBase(object):
         # it might lose some readability.
         # For each tgid we obtain the synapse parameters as a record array. We then split it,
         # without copying, yielding ranges (views) of it.
-
         gids = ProgressBar.iter(gids, name="Loading") if show_progress else gids
 
         for base_tgid in gids:
             tgid = base_tgid + tgid_offset
             syns_params = self._synapse_reader.get_synapse_parameters(base_tgid)
             logging.debug("GID %d Syn count: %d", tgid, len(syns_params))
-
-            if crash_test_mode:
-                # In large simulations some cells may have thousands of connections. Limit it!
-                syns_params = syns_params[:CRASH_TEST_MODE_MAX_CONNS_CELL]
 
             if self._load_offsets:
                 syn_index = self._synapse_reader.get_property(base_tgid, "synapse_index")

--- a/neurodamus/core/_utils.py
+++ b/neurodamus/core/_utils.py
@@ -18,7 +18,7 @@ class ProgressBarRank0(progressbar.Progress):
     """
     def __new__(cls, end, *args, **kwargs):
         if MPI.rank == 0:
-            return progressbar.ProgressBar(end, *args, tty_bar=(MPI.size == 1) and None, **kwargs)
+            return progressbar.ProgressBar(end, *args, tty_bar=False and None, **kwargs)
         return progressbar.Progress(end, *args, **kwargs)
 
 

--- a/neurodamus/io/synapse_reader.py
+++ b/neurodamus/io/synapse_reader.py
@@ -300,7 +300,6 @@ class SonataReader(SynapseReader):
         if minimal_mode:
             needed_edge_ids = libsonata.Selection(needed_edge_ids.flatten()[different_gids_edge_i])
             lookup_gids = lookup_gids[different_gids_edge_i]
-            needed_gids = sorted(lookup_gids)
 
         def _populate(field, data):
             # Populate cache. Unavailable entries are stored as a plain -1
@@ -396,8 +395,8 @@ class SonataReader(SynapseReader):
                 _populate("offset", _read("morpho_offset_segment_post"))
 
     def _load_synapse_parameters(self, gid):
-        data = self._data.get(gid, False)
-        if data is False:  # strictly compare to False (not in _data)
+        data = self._data.get(gid)
+        if data is None:  # not in _data
             self._preload_data_chunk([gid])
             data = self._data[gid]
 

--- a/neurodamus/io/synapse_reader.py
+++ b/neurodamus/io/synapse_reader.py
@@ -260,8 +260,8 @@ class SonataReader(SynapseReader):
         Preload SONATA fields for the specified IDs.
         Set minimal_mode to True to read a single synapse per connection
         """
-        # Ensure we dont ask synapses for more than 50 target cells at once
-        CHUNK_SIZE = 50
+        # Ensure we dont ask synapses for more than 1000 target cells at once
+        CHUNK_SIZE = 1000
         if len(gids) <= CHUNK_SIZE:
             return self._preload_data_chunk(gids, minimal_mode)
 

--- a/neurodamus/io/synapse_reader.py
+++ b/neurodamus/io/synapse_reader.py
@@ -272,8 +272,6 @@ class SonataReader(SynapseReader):
     def _preload_data_chunk(self, gids, minimal_mode=False):
         """Preload all synapses for a number of gids, respecting Parameters and _extra_fields"""
         # NOTE: to disambiguate, gids are 1-based cell ids, while node_ids are 0-based sonata ids
-        if not len(gids):
-            return
         compute_fields = set(("sgid", "tgid") + self.SYNAPSE_INDEX_NAMES)
         orig_needed_gids_set = set(gids) - set(self._data.keys())
         needed_gids = sorted(orig_needed_gids_set)

--- a/neurodamus/io/synapse_reader.py
+++ b/neurodamus/io/synapse_reader.py
@@ -260,9 +260,10 @@ class SonataReader(SynapseReader):
         Preload SONATA fields for the specified IDs.
         Set minimal_mode to True to read a single synapse per connection
         """
-        # Ensure we dont ask synapses for more than 1000 target cells at once
+        # TODO: limit the number of cells per chunk in production.
+        #       Ensuring the number of chunks must be the same in all ranks (collective)!
         CHUNK_SIZE = 1000
-        if len(gids) <= CHUNK_SIZE:
+        if not minimal_mode or len(gids) < CHUNK_SIZE:
             return self._preload_data_chunk(gids, minimal_mode)
 
         ranges = list(gen_ranges(len(gids), CHUNK_SIZE))

--- a/tests/integration-e2e/test_crashmode.py
+++ b/tests/integration-e2e/test_crashmode.py
@@ -27,6 +27,7 @@ def test_crash_test_cell_loading(SIM_DIR, tmp_path):
     n = Node(str(new_config_path), {"crash_test": True})
     n.load_targets()
     n.create_cells()
+    n.create_synapses()
 
     cell_manager: CellDistributor = n.circuits.get_node_manager("default")
     assert len(cell_manager.cells) == 18750

--- a/tests/integration-e2e/test_crashmode.py
+++ b/tests/integration-e2e/test_crashmode.py
@@ -27,7 +27,6 @@ def test_crash_test_cell_loading(SIM_DIR, tmp_path):
     n = Node(str(new_config_path), {"crash_test": True})
     n.load_targets()
     n.create_cells()
-    n.create_synapses()
 
     cell_manager: CellDistributor = n.circuits.get_node_manager("default")
     assert len(cell_manager.cells) == 18750
@@ -36,3 +35,7 @@ def test_crash_test_cell_loading(SIM_DIR, tmp_path):
     assert isinstance(cell0.soma, list)
     assert len(cell0.soma) == 1
     assert isinstance(cell0.soma[0], nrn.Section)
+
+    n.create_synapses()
+    syn_manager = n.circuits.get_edge_manager("default", "default")
+    assert syn_manager.connection_count == 18750


### PR DESCRIPTION
## Context

Speed up crash test mode to avoid loading as much data

## Scope

 - `SonataReader` to quickly find out cells for which we have no data and mark them with an empty dict
 - For cells which have some data, in crash-test mode restrict the fetching edge index to only one (the first) per target cell. This operating could be done exclusively with numpy indexing operations, and is therefore fast.