### PR TITLE
Pin Python versions

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -182,7 +182,7 @@ jobs:
     - name: Example run
       run: |
         . ./venv/bin/activate
-        if [ ${{ matrix.python-version }} == 3.9 ]; then
+        if [[ ${{ matrix.python-version }} == 3.9.* ]]; then
           export RDMAV_FORK_SAFE=1
         fi;
         export PYTHONPATH=$(pwd)/nrn/build/lib/python:$PYTHONPATH

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        python-version: ['3.9', '3.10', '3.11', '3.12.5']
+        python-version: ['3.9.20', '3.10.15', '3.11.10', '3.12.6']
     steps:
     - name: Setup Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
## Context

GHA setup-python, if not given the full python version, will install the latest patch.
However, since we cache venvs, things can go out of sync we and get errors like
```
/home/runner/work/neurodamus/neurodamus/venv/bin/python: bad interpreter: No such file or directory
```

## Scope

Specify all Python versions precisely.
Pros: simple, consistent CI, more cache reuse
Cons: CI won't automatically pick newer python patch versions. (Is it a problem?)

## Testing
Ci now passes

## Review
* [x] PR description is complete
