### PR TITLE
Synapse reading fixes

### DIFF
--- a/neurodamus/io/synapse_reader.py
+++ b/neurodamus/io/synapse_reader.py
@@ -348,7 +348,10 @@ class SonataReader(SynapseReader):
         # We nevertheless can skip any base fields
         extra_fields = set(self._extra_fields) - (self.Parameters.all_fields | compute_fields)
         for field in sorted(extra_fields):
-            now_needed_gids = sorted(set(gid for gid in gids if field not in self._data[gid]))
+            now_needed_gids = sorted(set(
+                gid for gid in gids
+                if (data := self._data[gid]) is not self.EMPTY_DATA and field not in data
+            ))
             if needed_gids != now_needed_gids:
                 needed_gids = now_needed_gids
                 needed_edge_ids, lookup_gids = get_edge_and_lookup_gids(needed_gids)

--- a/tests/integration-e2e/test_crashmode.py
+++ b/tests/integration-e2e/test_crashmode.py
@@ -2,7 +2,7 @@ import json
 import os
 
 
-def test_crash_test_cell_loading(SIM_DIR, tmp_path):
+def test_crash_test_loading(SIM_DIR, tmp_path):
     from neurodamus import Node
     from neurodamus.cell_distributor import CellDistributor
     from neurodamus.metype import PointCell
@@ -16,7 +16,7 @@ def test_crash_test_cell_loading(SIM_DIR, tmp_path):
     # Replace target with a large one (18k cells)
     # Test runs in a single rank and its still fast in crash-test mode
     new_config_path = tmp_path / "simulation_config.json"
-    config["node_set"] = "L4_PC"
+    config["node_set"] = "L4_SP"
     with open(new_config_path, "w") as new_config:
         json.dump(config, new_config)
 
@@ -29,7 +29,7 @@ def test_crash_test_cell_loading(SIM_DIR, tmp_path):
     n.create_cells()
 
     cell_manager: CellDistributor = n.circuits.get_node_manager("default")
-    assert len(cell_manager.cells) == 18750
+    assert len(cell_manager.cells) == 7687
     cell0 = next(iter(cell_manager.cells))
     assert isinstance(cell0, PointCell)
     assert isinstance(cell0.soma, list)
@@ -38,4 +38,4 @@ def test_crash_test_cell_loading(SIM_DIR, tmp_path):
 
     n.create_synapses()
     syn_manager = n.circuits.get_edge_manager("default", "default")
-    assert syn_manager.connection_count == 18750
+    assert syn_manager.connection_count == 7687


### PR DESCRIPTION
## Context
Fix an issue reading extra properties for cells where there is no synapses.

Error:
```
conn_syn_params[name] = data[name]
E           KeyError: 'weight'
```

## Scope

 - After recent optimizations, we dont create empty base properties. Therefore, extended empty properties must not be created either. 
 - We must ensure that when a gid is assigned EMPTY_DATA it is not considered, otherwise it would even ruin the shared empty dict. 

## Testing
wip..

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
