### PR TITLE
Fix ReadtheDocs PR build failure

### DIFF
--- a/docs/api/neurodamus.io.rst
+++ b/docs/api/neurodamus.io.rst
@@ -9,6 +9,6 @@ Sub-Modules
 
 .. autosummary::
 
-   neurodamus.io.cell_readers
-   neurodamus.io.sonata_config
-   neurodamus.io.synapse_reader
+   cell_readers
+   sonata_config
+   synapse_reader

--- a/docs/api/neurodamus.rst
+++ b/docs/api/neurodamus.rst
@@ -9,24 +9,24 @@ Package-Level Classes
 =====================
 
 .. autosummary::
-   neurodamus.Neurodamus
-   neurodamus.Node
+   Neurodamus
+   Node
 
 
 Sub-Modules
 ===========
 
 .. autosummary::
-   neurodamus.cell_distributor
-   neurodamus.connection_manager
-   neurodamus.connection
-   neurodamus.gap_junction
-   neurodamus.metype
-   neurodamus.modification_manager
-   neurodamus.ngv
-   neurodamus.replay
-   neurodamus.stimulus_manager
-   neurodamus.target_manager
+   cell_distributor
+   connection_manager
+   connection
+   gap_junction
+   metype
+   modification_manager
+   ngv
+   replay
+   stimulus_manager
+   target_manager
 
 
 Module API

--- a/docs/api/neurodamus.utils.rst
+++ b/docs/api/neurodamus.utils.rst
@@ -9,8 +9,8 @@ Sub-Modules
 
 .. autosummary::
 
-   neurodamus.utils.compat
-   neurodamus.utils.logging
-   neurodamus.utils.multimap
-   neurodamus.utils.progressbar
-   neurodamus.utils.pyutils
+   compat
+   logging
+   multimap
+   progressbar
+   pyutils


### PR DESCRIPTION
## Context
After enabling the PR build for ReadtheDocs, we got doc build failure such as:
```
WARNING: Summarised items should not include the current module. Replace 'neurodamus.Neurodamus' with 'Neurodamus'. [autosummary.import_cycle]
WARNING: Summarised items should not include the current module. Replace 'neurodamus.Node' with 'Node'. [autosummary.import_cycle]
WARNING: Summarised items should not include the current module. Replace 'neurodamus.cell_distributor' with 'cell_distributor'. [autosummary.import_cycle]
...
```
This PR fixes the relevant doc files according to those warnings.
## Testing
ReadtheDocs PR build

## Review
* [x] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [x] Updated Readme, in-code, developer documentation
