### PR TITLE
Fix: Avoid extraneous newline

### DIFF
--- a/tools/rebalance-corenrn-data.py
+++ b/tools/rebalance-corenrn-data.py
@@ -47,7 +47,7 @@ def redistribute_files_dat(files_dat_file, n_buckets, max_entries=None, show_sta
     with open(files_dat_file, "r") as file:
         # read header
         metadata["version"] = file.readline().strip()
-        n_entries = file.readline()
+        n_entries = file.readline().strip()
 
         metadata["n_files"] = max_entries or n_entries
 


### PR DESCRIPTION
## Scope

This PR fixes an issue in the output (rebalanced) files.dat in which the "number of files" header would be followed by a new line. This only occured when `--max-entries` was not being specified

## Testing
Tested with proj134/home/king/BBPP134-917/p_MultiCycle_Support
