### PR TITLE
Fix Save/Restore coreneuron_input issue: create symlink to the save coreneuron_input folder

### DIFF
--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -879,8 +879,8 @@ def _coreneuron_params(config: _SimConfig, run_conf):
     if config.use_coreneuron and config.restore:
         # Most likely we will need to reuse coreneuron_input from first part
         if not os.path.isdir(coreneuron_datadir):
-            logging.info("RESTORE: Searching for coreneuron_input besides " + config.restore)
-            coreneuron_datadir = os.path.join(config.restore, "..", "coreneuron_input")
+            logging.info("RESTORE: link to coreneuron_input besides " + config.restore)
+            os.symlink(os.path.join(config.restore, "..", "coreneuron_input"), coreneuron_datadir)
         assert os.path.isdir(coreneuron_datadir), "coreneuron_input dir not found"
 
     config.coreneuron_datadir = coreneuron_datadir

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -877,7 +877,8 @@ def _coreneuron_params(config: _SimConfig, run_conf):
     coreneuron_datadir = os.path.join(config.output_root, "coreneuron_input")
 
     if config.use_coreneuron and config.restore:
-        # Most likely we will need to reuse coreneuron_input from first part
+        # Most likely we will need to reuse coreneuron_input from the save part
+        # A symlink is created for the scenario of multiple save/restore processes in one simulation
         if not os.path.isdir(coreneuron_datadir):
             logging.info("RESTORE: link to coreneuron_input besides " + config.restore)
             os.symlink(os.path.join(config.restore, "..", "coreneuron_input"), coreneuron_datadir)

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -880,7 +880,8 @@ def _coreneuron_params(config: _SimConfig, run_conf):
         # Most likely we will need to reuse coreneuron_input from the save part
         # A symlink is created for the scenario of multiple save/restore processes in one simulation
         if not os.path.isdir(coreneuron_datadir):
-            logging.info("RESTORE: link to coreneuron_input besides " + config.restore)
+            logging.info("RESTORE: Create a symlink for coreneuron_input pointing to "
+                         + config.restore)
             os.symlink(os.path.join(config.restore, "..", "coreneuron_input"), coreneuron_datadir)
         assert os.path.isdir(coreneuron_datadir), "coreneuron_input dir not found"
 

--- a/tests/integration-e2e/test_cli_opts.py
+++ b/tests/integration-e2e/test_cli_opts.py
@@ -16,15 +16,16 @@ def test_save_restore_cli():
     with open(SIM_DIR / CONFIG_FILE_MINI, "r") as f:
         sim_config_data = json.load(f)
 
+    # params (cli_options, output_dir, tstop) for 3 test scenarios: save, save-restore, restore
+    test1_params = ([("save", "output_p1/checkpoint")], "output_p1", 100)
+    test2_params = (
+        [("save", "output_p2/checkpoint"), ("restore", "output_p1/checkpoint")], "output_p2", 150
+        )
+    test3_params = ([("restore", "output_p2/checkpoint")], "output_p3", 200)
     for simulator in ("NEURON", "CORENEURON"):
         test_folder = tempfile.TemporaryDirectory("cli-test-" + simulator)  # auto removed
         test_folder_path = Path(test_folder.name)
-        for actions, output_dir, tstop in (([("save", "output_p1/checkpoint")], "output_p1", 100),
-                                           ([("save", "output_p2/checkpoint"),
-                                             ("restore", "output_p1/checkpoint")],
-                                            "output_p2", 150),
-                                           ([("restore", "output_p2/checkpoint")],
-                                            "output_p3", 200)):
+        for v_cli_options, output_dir, tstop in (test1_params, test2_params, test3_params):
             sim_config_data["target_simulator"] = simulator
             sim_config_data["run"]["tstop"] = tstop
             sim_config_data["output"]["output_dir"] = str(test_folder_path / output_dir)
@@ -34,7 +35,7 @@ def test_save_restore_cli():
                 json.dump(sim_config_data, f, indent=2)
 
             cli_options = ["--" + action + "=" + str(test_folder_path / action_folder)
-                           for action, action_folder in actions]
+                           for action, action_folder in v_cli_options]
             command = ["neurodamus", test_folder_path / CONFIG_FILE_MINI] + cli_options
             # Save-Restore raises exception when using NEURON
             if simulator == "NEURON":

--- a/tests/integration-e2e/test_cli_opts.py
+++ b/tests/integration-e2e/test_cli_opts.py
@@ -19,20 +19,23 @@ def test_save_restore_cli():
     for simulator in ("NEURON", "CORENEURON"):
         test_folder = tempfile.TemporaryDirectory("cli-test-" + simulator)  # auto removed
         test_folder_path = Path(test_folder.name)
-        for action, tstop in (("save", 100), ("restore", 200)):
+        for actions, output_dir, tstop in (([("save", "output_p1/checkpoint")], "output_p1", 100),
+                                           ([("save", "output_p2/checkpoint"),
+                                             ("restore", "output_p1/checkpoint")],
+                                            "output_p2", 150),
+                                           ([("restore", "output_p2/checkpoint")],
+                                            "output_p3", 200)):
             sim_config_data["target_simulator"] = simulator
             sim_config_data["run"]["tstop"] = tstop
-            sim_config_data["output"]["output_dir"] = str(test_folder_path / ("output-" + action))
+            sim_config_data["output"]["output_dir"] = str(test_folder_path / output_dir)
             sim_config_data["network"] = str(SIM_DIR / CIRCUIT_DIR / "circuit_config.json")
 
             with open(test_folder_path / CONFIG_FILE_MINI, "w") as f:
                 json.dump(sim_config_data, f, indent=2)
 
-            # Checkpoints inside the output good tradition w CoreNeuron
-            checkpoint_dir = test_folder_path / "output-save" / "checkpoint"
-
-            command = ["neurodamus", test_folder_path / CONFIG_FILE_MINI,
-                        "--" + action + "=" + str(checkpoint_dir)]
+            cli_options = ["--" + action + "=" + str(test_folder_path / action_folder)
+                           for action, action_folder in actions]
+            command = ["neurodamus", test_folder_path / CONFIG_FILE_MINI] + cli_options
             # Save-Restore raises exception when using NEURON
             if simulator == "NEURON":
                 with pytest.raises(subprocess.CalledProcessError):


### PR DESCRIPTION
## Context
Users should be able to run several save & restore processes in sequence for one simulation, explained in [wiki](https://github.com/BlueBrain/neurodamus/wiki/Using-CoreNeuron-in-Practice#using-save-restore-for-long-running-simulations). However, currently the restore uses the direct `coreneuron_input` folder from its `save` output directory, so it would lead to error `coreneuron_input dir not found` for multiple restores such as "save -> save & restore -> restore" because the 2nd restore only knows its previous save folder. Therefore, this PR tries to fix it by creating a symlink pointing to the `coreneuron_input` in the `save` output directory.  At the end of the last restore, this link will be removed by an existing function in `node.py`.

## Scope
Create a `symlink` in `_coreneuron_params` for restore. 

## Testing
Improve `test_save_restore_cli` in `test_cli_opts.py` that it runs 2 restore process in a chain. 

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
