### PR TITLE
Replace unmaintained docopt with docopt-ng

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.rst"
 dynamic = ["version"]
 dependencies = [
     "h5py",
-    "docopt",
+    "docopt-ng",
     "libsonata",
     "psutil"
 ]


### PR DESCRIPTION
The last `docopt` release was in 2014, compare that to the more modern https://pypi.org/project/docopt-ng/