### PR TITLE
[Release 3.7.1]: fix publishing to PyPI by using trusted publisher

### DIFF
--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -28,12 +28,24 @@ jobs:
           cd $GITHUB_WORKSPACE
           pip3 install tox
           DIST_FILE=`ls dist/*whl` && tox --installpkg=$DIST_FILE -e ${{ matrix.python_version }}
+  pypi-publish:
+    runs-on: ubuntu-22.04
+    # IMPORTANT: this permission is mandatory for trusted publishing
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts produced by the Build Wheel job
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: dist
+
       - name: Upload Wheel
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        env:
-            PYPI_URL: ${{ secrets.PYPI_URL }}
-            PYPI_USER: ${{ secrets.PYPI_USER }}
-            PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          pip3 install twine
-          python${{ matrix.python_version }} -m twine upload --username $PYPI_USER --password $PYPI_TOKEN dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages_dir: dist/

--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -28,17 +28,23 @@ jobs:
           cd $GITHUB_WORKSPACE
           pip3 install tox
           DIST_FILE=`ls dist/*whl` && tox --installpkg=$DIST_FILE -e ${{ matrix.python_version }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.python_version }}-${{ strategy.job-index }}
+          path: ./dist/*.whl
   pypi-publish:
     runs-on: ubuntu-22.04
+    needs: [wheel]
     # IMPORTANT: this permission is mandatory for trusted publishing
     permissions:
       id-token: write
     steps:
-      - name: Download artifacts produced by the Build Wheel job
+      - name: Download artifacts produced by the wheel job
         uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: wheels*
           path: dist/
+          merge-multiple: true
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Change Log
 ==========
 
+Version 3.7.1
+=============
+**6 December 2024**
+
+*Bug Fixes*
+  * Fix publishing to PyPI by using trusted publisher (#228)
+
+
 Version 3.7.0
 =============
 **5 December 2024**

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@
 =============
 Neurodamus
 =============
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.8075201.svg
-   :target: https://doi.org/10.5281/zenodo.8075201
+.. image:: https://zenodo.org/badge/640796304.svg
+  :target: https://doi.org/10.5281/zenodo.8075201
 
 
 Neurodamus is a BBP Simulation Control application for Neuron.


### PR DESCRIPTION
## Context
When publish release 3.7.0 to PyPI, we got the error `Username/Password authentication is no longer supported. Migrate to API  Tokens or Trusted Publishers instead`. This PR migrates to trusted publishers.

## Scope
* Change in the github actions workflow for publishing wheels.
* Also update DOI badge in README.

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
