### PR TITLE
[Release 3.7.2]: make sure sdist is also published

### DIFF
--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.python_version }}-${{ strategy.job-index }}
-          path: ./dist/*.whl
+          path: ./dist/*
   pypi-publish:
     runs-on: ubuntu-22.04
     needs: [wheel]

--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -30,7 +30,7 @@ jobs:
           DIST_FILE=`ls dist/*whl` && tox --installpkg=$DIST_FILE -e ${{ matrix.python_version }}
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.python_version }}-${{ strategy.job-index }}
+          name: release-artifacts-${{ matrix.python_version }}-${{ strategy.job-index }}
           path: ./dist/*
   pypi-publish:
     runs-on: ubuntu-22.04
@@ -42,7 +42,7 @@ jobs:
       - name: Download artifacts produced by the wheel job
         uses: actions/download-artifact@v4
         with:
-          pattern: wheels*
+          pattern: release-artifacts*
           path: dist/
           merge-multiple: true
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Change Log
 ==========
 
+Version 3.7.2
+=============
+**6 December 2024**
+
+*Bug Fixes*
+  *  Make sure sdist is also published (#229)
+
+
 Version 3.7.1
 =============
 **6 December 2024**


### PR DESCRIPTION
## Context
3.7.1 was published without a source distribution. This PR adds publishing an sdist

## Scope
* Change in the github actions workflow for publishing sdist

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
