### PR TITLE
NEURON's NMODL language should now be properly recognized by GitHub.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 *.asc linguist-detectable=false
-*.mod linguist-detectable=false


### PR DESCRIPTION
See https://github.com/neuronsimulator/nrn sidebar.
